### PR TITLE
test: add unit tests for Username <WIP>

### DIFF
--- a/test/graph/Graph.t.sol
+++ b/test/graph/Graph.t.sol
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import "forge-std/Test.sol";
+import {Graph, Follow, IGraphRule, IFollowRule} from "../../contracts/primitives/graph/Graph.sol";
+import {OwnerOnlyAccessControl} from "../../contracts/primitives/access-control/OwnerOnlyAccessControl.sol";
+import {
+    AddressBasedAccessControl,
+    IRoleBasedAccessControl
+} from "../../contracts/primitives/access-control/AddressBasedAccessControl.sol";
+import {MockGraphRule} from "../mock/MockGraphRule.sol";
+import {MockFollowRule} from "../mock/MockFollowRule.sol";
+
+contract GraphTest is Test {
+    Graph public graph;
+    AddressBasedAccessControl public addressBasedAccessControl;
+    OwnerOnlyAccessControl public ownerOnlyAccessControl;
+    address public owner = address(1);
+    address public adminSetRules = address(2);
+    address public adminSetMetadata = address(3);
+    address public addminChangeAccessControl = address(4);
+    address public user1 = address(5);
+    address public user2 = address(6);
+    address public user3 = address(7);
+
+    uint256 constant SET_RULES_RID = uint256(keccak256("SET_RULES"));
+    uint256 constant SET_METADATA_RID = uint256(keccak256("SET_METADATA"));
+    uint256 constant CHANGE_ACCESS_CONTROL_RID = uint256(keccak256("CHANGE_ACCESS_CONTROL"));
+
+    function setUp() public {
+        vm.startPrank(owner);
+        addressBasedAccessControl = new AddressBasedAccessControl(owner);
+        ownerOnlyAccessControl = new OwnerOnlyAccessControl(owner);
+        // Set up roles
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(adminSetRules)), SET_RULES_RID, IRoleBasedAccessControl.AccessPermission.GRANTED, ""
+        );
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(adminSetMetadata)), SET_METADATA_RID, IRoleBasedAccessControl.AccessPermission.GRANTED, ""
+        );
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(addminChangeAccessControl)),
+            CHANGE_ACCESS_CONTROL_RID,
+            IRoleBasedAccessControl.AccessPermission.GRANTED,
+            ""
+        );
+        graph = new Graph("test-graph", addressBasedAccessControl);
+        vm.stopPrank();
+    }
+
+    function testSetGraphRulesWithCorrectRole() public {
+        IGraphRule mockRules = IGraphRule(address(5));
+
+        vm.prank(adminSetRules);
+        graph.setGraphRules(mockRules);
+
+        assertEq(address(graph.getGraphRules()), address(mockRules));
+    }
+
+    function testCannotSetGraphRulesWithoutCorrectRole() public {
+        IGraphRule mockRules = IGraphRule(address(5));
+
+        vm.prank(user1);
+        vm.expectRevert();
+        graph.setGraphRules(mockRules);
+    }
+
+    function testSetAccessControlWithCorrectRole() public {
+        vm.prank(addminChangeAccessControl);
+        graph.setAccessControl(ownerOnlyAccessControl);
+    }
+
+    function testCannotSetAccessControlWithoutCorrectRole() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        graph.setAccessControl(ownerOnlyAccessControl);
+    }
+
+    function testSetFollowRules() public {
+        IFollowRule mockFollowRules = IFollowRule(address(5));
+
+        vm.prank(user1);
+        graph.setFollowRules(user1, mockFollowRules, "");
+
+        assertEq(address(graph.getFollowRules(user1)), address(mockFollowRules));
+    }
+
+    function testSetFollowRulesWithGraphRules() public {
+        // Set up mock graph rules
+        MockGraphRule mockGraphRule = new MockGraphRule();
+        vm.prank(owner);
+        graph.setGraphRules(mockGraphRule);
+
+        IFollowRule mockFollowRules = IFollowRule(address(6));
+        bytes memory testData = "test data";
+
+        vm.prank(user1);
+        graph.setFollowRules(user1, mockFollowRules, testData);
+
+        // Check that the follow rules were set
+        assertEq(address(graph.getFollowRules(user1)), address(mockFollowRules));
+
+        // Check that processFollowRulesChange was called on the mock graph rules
+        assertTrue(mockGraphRule.processFollowRulesChangeCalled());
+        assertEq(mockGraphRule.lastAccount(), user1);
+        assertEq(address(mockGraphRule.lastFollowRules()), address(mockFollowRules));
+        assertEq(mockGraphRule.lastData(), testData);
+    }
+
+    function testCannotSetFollowRulesForOtherAccount() public {
+        IFollowRule mockFollowRules = IFollowRule(address(6));
+        bytes memory testData = "test data";
+
+        vm.prank(user2);
+        vm.expectRevert();
+        graph.setFollowRules(user1, mockFollowRules, testData);
+    }
+
+    function testFollow() public {
+        vm.prank(user1);
+        uint256 followId = graph.follow(user1, user2, 0, "", "");
+
+        assertTrue(graph.isFollowing(user1, user2));
+        assertEq(graph.getFollowersCount(user2), 1);
+        assertEq(graph.getFollowerById(user2, followId), user1);
+
+        Follow memory follow = graph.getFollow(user1, user2);
+        assertEq(follow.id, followId);
+        assertEq(follow.timestamp, block.timestamp);
+    }
+
+    function testFollowWithSpecificId() public {
+        uint256 specificId = 5;
+        vm.startPrank(user1);
+        uint256 followId;
+
+        // Increment followId by 1 each time
+        for (uint256 i = 0; i < specificId + 1; i++) {
+            followId = graph.follow(user1, user2, 0, "", "");
+            graph.unfollow(user1, user2, "");
+        }
+
+        followId = graph.follow(user1, user2, specificId, "", "");
+
+        assertEq(followId, specificId);
+        assertTrue(graph.isFollowing(user1, user2));
+        assertEq(graph.getFollowersCount(user2), 1);
+        assertEq(graph.getFollowerById(user2, followId), user1);
+    }
+
+    function testFollowWithGraphRules() public {
+        MockGraphRule mockGraphRule = new MockGraphRule();
+        vm.prank(owner);
+        graph.setGraphRules(mockGraphRule);
+
+        bytes memory graphRulesData = "graph rules data";
+        vm.prank(user1);
+        uint256 followId = graph.follow(user1, user2, 0, graphRulesData, "");
+
+        assertTrue(mockGraphRule.processFollowCalled());
+        assertEq(mockGraphRule.lastFollowerAccount(), user1);
+        assertEq(mockGraphRule.lastTargetAccount(), user2);
+        assertEq(mockGraphRule.lastFollowId(), followId);
+        assertEq(mockGraphRule.lastGraphRulesData(), graphRulesData);
+    }
+
+    function testFollowWithFollowRules() public {
+        MockFollowRule mockFollowRule = new MockFollowRule();
+
+        vm.prank(user2);
+        graph.setFollowRules(user2, mockFollowRule, "");
+
+        bytes memory followRulesData = "follow rules data";
+        vm.prank(user1);
+        uint256 followId = graph.follow(user1, user2, 0, "", followRulesData);
+
+        assertTrue(mockFollowRule.processFollowCalled());
+        assertEq(mockFollowRule.lastFollowerAccount(), user1);
+        assertEq(mockFollowRule.lastFollowId(), followId);
+        assertEq(mockFollowRule.lastFollowRulesData(), followRulesData);
+    }
+
+    function testCannotFollowUsingOtherAccount() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        graph.follow(user2, user1, 0, "", "");
+    }
+
+    function testCannotFollowTwice() public {
+        vm.startPrank(user1);
+        graph.follow(user1, user2, 0, "", "");
+
+        vm.expectRevert();
+        graph.follow(user1, user2, 0, "", "");
+        vm.stopPrank();
+
+        assertEq(graph.getFollowersCount(user2), 1);
+    }
+
+    function testCannotFollowSelf() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        graph.follow(user1, user1, 0, "", "");
+        assertEq(graph.getFollowersCount(user1), 0);
+    }
+
+    function testCannotFollowWithIdMoreThanLastIdAssigned() public {
+        uint256 specificId = 42;
+        vm.prank(user1);
+
+        // Follow ID more than lastFollowIdAssigned
+        vm.expectRevert();
+        uint256 followId = graph.follow(user1, user2, specificId, "", "");
+    }
+
+    function testCannotFollowWithTakenId() public {
+        vm.prank(user1);
+        // Increase the current followId of user3 to 1
+        uint256 followId = graph.follow(user1, user3, 0, "", "");
+        assertEq(followId, 1);
+
+        // Transaction reverted because followId is already taken
+        vm.prank(user2);
+        vm.expectRevert();
+        graph.follow(user2, user3, 1, "", "");
+    }
+
+    function testUnfollow() public {
+        vm.startPrank(user1);
+        graph.follow(user1, user2, 0, "", "");
+        uint256 followId = graph.unfollow(user1, user2, "");
+        vm.stopPrank();
+
+        assertFalse(graph.isFollowing(user1, user2));
+        assertEq(graph.getFollowersCount(user2), 0);
+        assertEq(graph.getFollowerById(user2, followId), address(0));
+    }
+
+    function testUnfollowWithGraphRules() public {
+        MockGraphRule mockGraphRule = new MockGraphRule();
+        vm.prank(owner);
+        graph.setGraphRules(mockGraphRule);
+
+        vm.prank(user1);
+        uint256 followId = graph.follow(user1, user2, 0, "", "");
+
+        bytes memory graphRulesData = "unfollow graph rules data";
+        vm.prank(user1);
+        uint256 unfollowId = graph.unfollow(user1, user2, graphRulesData);
+
+        assertTrue(mockGraphRule.processUnfollowCalled());
+        assertEq(mockGraphRule.lastUnfollowerAccount(), user1);
+        assertEq(mockGraphRule.lastUnfollowedAccount(), user2);
+        assertEq(mockGraphRule.lastUnfollowId(), unfollowId);
+        assertEq(mockGraphRule.lastUnfollowGraphRulesData(), graphRulesData);
+        assertEq(followId, unfollowId);
+    }
+
+    function testCannotUnfollowWithoutFollowing() public {
+        vm.prank(user1);
+        vm.expectRevert();
+        graph.unfollow(user1, user2, "");
+    }
+
+    function testCannotUnfollowUsingOtherAccount() public {
+        vm.prank(user1);
+        graph.follow(user1, user2, 0, "", "");
+
+        vm.prank(user3);
+        vm.expectRevert();
+        graph.unfollow(user1, user2, "");
+    }
+}

--- a/test/graph/GraphRuleCombinator.t.sol
+++ b/test/graph/GraphRuleCombinator.t.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import "forge-std/Test.sol";
+import {
+    GraphRuleCombinator, RuleCombinator, IFollowRule
+} from "../../contracts/primitives/graph/GraphRuleCombinator.sol";
+import {OwnerOnlyAccessControl} from "../../contracts/primitives/access-control/OwnerOnlyAccessControl.sol";
+import {MockGraphRule} from "../mock/MockGraphRule.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract GraphRuleCombinatorTest is Test {
+    GraphRuleCombinator public combinator;
+    OwnerOnlyAccessControl public accessControl;
+    MockGraphRule public rule1;
+    MockGraphRule public rule2;
+
+    address public owner = address(1);
+    address public user1 = address(2);
+    address public user2 = address(3);
+
+    // Events from MockGraphRule
+    event ProcessFollowCalled(address followerAccount, address targetAccount, uint256 followId, bytes graphRulesData);
+    event ProcessUnfollowCalled(
+        address unfollowerAccount, address unfollowedAccount, uint256 unfollowId, bytes graphRulesData
+    );
+    event ProcessFollowRulesChangeCalled(address account, IFollowRule followRules, bytes data);
+    event ProcessBlockCalled(address account, bytes data);
+    event ProcessUnblockCalled(address account, bytes data);
+
+    function setUp() public {
+        vm.startPrank(owner);
+        accessControl = new OwnerOnlyAccessControl(owner);
+        address impl = address(new GraphRuleCombinator());
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), "");
+        combinator = GraphRuleCombinator(address(proxy));
+        rule1 = new MockGraphRule();
+        rule2 = new MockGraphRule();
+        vm.stopPrank();
+    }
+
+    function testInitialize() public {
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.AND, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+        vm.stopPrank();
+
+        assertEq(address(combinator.getAccessControl()), address(accessControl));
+        assertEq(uint256(combinator.getCombinationMode()), uint256(RuleCombinator.CombinationMode.AND));
+    }
+
+    function testAddRules() public {
+        // First initialize
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.AND, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+
+        // Then add rules
+        RuleCombinator.RuleConfiguration[] memory rules = new RuleCombinator.RuleConfiguration[](2);
+        rules[0] = RuleCombinator.RuleConfiguration(address(rule1), "");
+        rules[1] = RuleCombinator.RuleConfiguration(address(rule2), "");
+
+        bytes memory addRulesData = abi.encode(rules);
+        combinator.configure(abi.encode(RuleCombinator.Operation.ADD_RULES, addRulesData));
+        vm.stopPrank();
+
+        address[] memory addedRules = combinator.getRules();
+        assertEq(addedRules.length, 2);
+        assertEq(addedRules[0], address(rule1));
+        assertEq(addedRules[1], address(rule2));
+    }
+
+    function testProcessFollowANDMode() public {
+        // Initialize and add rules
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.AND, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+
+        RuleCombinator.RuleConfiguration[] memory rules = new RuleCombinator.RuleConfiguration[](2);
+        rules[0] = RuleCombinator.RuleConfiguration(address(rule1), "");
+        rules[1] = RuleCombinator.RuleConfiguration(address(rule2), "");
+
+        bytes memory addRulesData = abi.encode(rules);
+        combinator.configure(abi.encode(RuleCombinator.Operation.ADD_RULES, addRulesData));
+        vm.stopPrank();
+
+        // Test process follow
+        bytes[] memory rulesData = new bytes[](2);
+        rulesData[0] = "data1";
+        rulesData[1] = "data2";
+        bytes memory data = abi.encode(rulesData);
+
+        // Events from MockGraphRule
+        vm.expectEmit();
+        emit ProcessFollowCalled(user1, user2, 1, "data1");
+        vm.expectEmit();
+        emit ProcessFollowCalled(user1, user2, 1, "data2");
+        combinator.processFollow(user1, user1, user2, 1, data);
+    }
+
+    function testProcessUnfollowANDMode() public {
+        // Initialize and add rules
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.AND, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+
+        RuleCombinator.RuleConfiguration[] memory rules = new RuleCombinator.RuleConfiguration[](2);
+        rules[0] = RuleCombinator.RuleConfiguration(address(rule1), "");
+        rules[1] = RuleCombinator.RuleConfiguration(address(rule2), "");
+
+        bytes memory addRulesData = abi.encode(rules);
+        combinator.configure(abi.encode(RuleCombinator.Operation.ADD_RULES, addRulesData));
+        vm.stopPrank();
+
+        // Test process unfollow
+        bytes[] memory rulesData = new bytes[](2);
+        rulesData[0] = "data1";
+        rulesData[1] = "data2";
+        bytes memory data = abi.encode(rulesData);
+
+        // Events from MockGraphRule
+        vm.expectEmit();
+        emit ProcessUnfollowCalled(user1, user2, 1, "data1");
+        vm.expectEmit();
+        emit ProcessUnfollowCalled(user1, user2, 1, "data2");
+        combinator.processUnfollow(user1, user1, user2, 1, data);
+    }
+
+    function testProcessFollowRulesChangeANDMode() public {
+        // Initialize and add rules
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.AND, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+
+        RuleCombinator.RuleConfiguration[] memory rules = new RuleCombinator.RuleConfiguration[](2);
+        rules[0] = RuleCombinator.RuleConfiguration(address(rule1), "");
+        rules[1] = RuleCombinator.RuleConfiguration(address(rule2), "");
+
+        bytes memory addRulesData = abi.encode(rules);
+        combinator.configure(abi.encode(RuleCombinator.Operation.ADD_RULES, addRulesData));
+        vm.stopPrank();
+
+        // Test process follow rules change
+        IFollowRule mockFollowRule = IFollowRule(address(0x123));
+        bytes[] memory rulesData = new bytes[](2);
+        rulesData[0] = "data1";
+        rulesData[1] = "data2";
+        bytes memory data = abi.encode(rulesData);
+
+        // Events from MockGraphRule
+        vm.expectEmit();
+        emit ProcessFollowRulesChangeCalled(user1, mockFollowRule, "data1");
+        vm.expectEmit();
+        emit ProcessFollowRulesChangeCalled(user1, mockFollowRule, "data2");
+        combinator.processFollowRulesChange(user1, mockFollowRule, data);
+    }
+
+    function testProcessFollowORMode() public {
+        // Initialize and add rules
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.OR, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+
+        RuleCombinator.RuleConfiguration[] memory rules = new RuleCombinator.RuleConfiguration[](2);
+        rules[0] = RuleCombinator.RuleConfiguration(address(rule1), "");
+        rules[1] = RuleCombinator.RuleConfiguration(address(rule2), "");
+
+        bytes memory addRulesData = abi.encode(rules);
+        combinator.configure(abi.encode(RuleCombinator.Operation.ADD_RULES, addRulesData));
+        vm.stopPrank();
+
+        // Test process follow
+        bytes[] memory rulesData = new bytes[](2);
+        rulesData[0] = "data1";
+        rulesData[1] = "data2";
+        bytes memory data = abi.encode(rulesData);
+
+        // Expect only the first rule to be called in OR mode
+        vm.expectEmit();
+        emit ProcessFollowCalled(user1, user2, 1, "data1");
+        combinator.processFollow(user1, user1, user2, 1, data);
+    }
+
+    function testProcessUnfollowORMode() public {
+        // Initialize and add rules
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.OR, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+
+        RuleCombinator.RuleConfiguration[] memory rules = new RuleCombinator.RuleConfiguration[](2);
+        rules[0] = RuleCombinator.RuleConfiguration(address(rule1), "");
+        rules[1] = RuleCombinator.RuleConfiguration(address(rule2), "");
+
+        bytes memory addRulesData = abi.encode(rules);
+        combinator.configure(abi.encode(RuleCombinator.Operation.ADD_RULES, addRulesData));
+        vm.stopPrank();
+
+        // Test process unfollow
+        bytes[] memory rulesData = new bytes[](2);
+        rulesData[0] = "data1";
+        rulesData[1] = "data2";
+        bytes memory data = abi.encode(rulesData);
+
+        // Expect only the first rule to be called in OR mode
+        vm.expectEmit();
+        emit ProcessUnfollowCalled(user1, user2, 1, "data1");
+        combinator.processUnfollow(user1, user1, user2, 1, data);
+    }
+
+    function testProcessFollowRulesChangeORMode() public {
+        // Initialize and add rules
+        vm.startPrank(owner);
+        bytes memory initData = abi.encode(RuleCombinator.CombinationMode.OR, address(accessControl), "");
+        combinator.configure(abi.encode(RuleCombinator.Operation.INITIALIZE, initData));
+
+        RuleCombinator.RuleConfiguration[] memory rules = new RuleCombinator.RuleConfiguration[](2);
+        rules[0] = RuleCombinator.RuleConfiguration(address(rule1), "");
+        rules[1] = RuleCombinator.RuleConfiguration(address(rule2), "");
+
+        bytes memory addRulesData = abi.encode(rules);
+        combinator.configure(abi.encode(RuleCombinator.Operation.ADD_RULES, addRulesData));
+        vm.stopPrank();
+
+        // Test process follow rules change
+        IFollowRule mockFollowRule = IFollowRule(address(0x123));
+        bytes[] memory rulesData = new bytes[](2);
+        rulesData[0] = "data1";
+        rulesData[1] = "data2";
+        bytes memory data = abi.encode(rulesData);
+
+        // Expect only the first rule to be called in OR mode
+        vm.expectEmit();
+        emit ProcessFollowRulesChangeCalled(user1, mockFollowRule, "data1");
+        combinator.processFollowRulesChange(user1, mockFollowRule, data);
+    }
+}

--- a/test/mock/MockFollowRule.sol
+++ b/test/mock/MockFollowRule.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import "../../contracts/primitives/graph/IFollowRule.sol";
+
+contract MockFollowRule is IFollowRule {
+    bool public processFollowCalled;
+    address public lastFollowerAccount;
+    uint256 public lastFollowId;
+    bytes public lastFollowRulesData;
+
+    function processFollow(address, address followerAccount, uint256 followId, bytes calldata followRulesData)
+        external
+        override
+    {
+        processFollowCalled = true;
+        lastFollowerAccount = followerAccount;
+        lastFollowId = followId;
+        lastFollowRulesData = followRulesData;
+    }
+
+    function configure(bytes calldata data) external override {}
+}

--- a/test/mock/MockGraphRule.sol
+++ b/test/mock/MockGraphRule.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import "../../contracts/primitives/graph/IGraphRule.sol";
+
+contract MockGraphRule is IGraphRule {
+    bool public processFollowRulesChangeCalled;
+    address public lastAccount;
+    IFollowRule public lastFollowRules;
+    bytes public lastData;
+
+    // For processFollow
+    bool public processFollowCalled;
+    address public lastFollowerAccount;
+    address public lastTargetAccount;
+    uint256 public lastFollowId;
+    bytes public lastGraphRulesData;
+
+    // For processUnfollow
+    bool public processUnfollowCalled;
+    address public lastUnfollowerAccount;
+    address public lastUnfollowedAccount;
+    uint256 public lastUnfollowId;
+    bytes public lastUnfollowGraphRulesData;
+
+    event ProcessFollowCalled(address followerAccount, address targetAccount, uint256 followId, bytes graphRulesData);
+    event ProcessUnfollowCalled(
+        address unfollowerAccount, address unfollowedAccount, uint256 unfollowId, bytes graphRulesData
+    );
+    event ProcessFollowRulesChangeCalled(address account, IFollowRule followRules, bytes data);
+    event ProcessBlockCalled(address account, bytes data);
+    event ProcessUnblockCalled(address account, bytes data);
+
+    function processFollowRulesChange(address account, IFollowRule followRules, bytes calldata data)
+        external
+        override
+    {
+        processFollowRulesChangeCalled = true;
+        lastAccount = account;
+        lastFollowRules = followRules;
+        lastData = data;
+        emit ProcessFollowRulesChangeCalled(account, followRules, data);
+    }
+
+    function processFollow(
+        address,
+        address followerAccount,
+        address targetAccount,
+        uint256 followId,
+        bytes calldata graphRulesData
+    ) external override {
+        processFollowCalled = true;
+        lastFollowerAccount = followerAccount;
+        lastTargetAccount = targetAccount;
+        lastFollowId = followId;
+        lastGraphRulesData = graphRulesData;
+        emit ProcessFollowCalled(followerAccount, targetAccount, followId, graphRulesData);
+    }
+
+    function processUnfollow(
+        address,
+        address unfollowerAccount,
+        address unfollowedAccount,
+        uint256 unfollowId,
+        bytes calldata graphRulesData
+    ) external override {
+        processUnfollowCalled = true;
+        lastUnfollowerAccount = unfollowerAccount;
+        lastUnfollowedAccount = unfollowedAccount;
+        lastUnfollowId = unfollowId;
+        lastUnfollowGraphRulesData = graphRulesData;
+        emit ProcessUnfollowCalled(unfollowerAccount, unfollowedAccount, unfollowId, graphRulesData);
+    }
+
+    function processBlock(address account, bytes calldata data) external override {
+        emit ProcessBlockCalled(account, data);
+    }
+
+    function processUnblock(address account, bytes calldata data) external override {
+        emit ProcessUnblockCalled(account, data);
+    }
+
+    function configure(bytes calldata data) external override {}
+}

--- a/test/mock/MockUsernameRule.sol
+++ b/test/mock/MockUsernameRule.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import {IUsernameRule} from "../../contracts/primitives/username/IUsernameRule.sol";
+
+contract MockUsernameRule is IUsernameRule {
+    function processRegistering(address, address, string memory, bytes calldata) external pure override {}
+    function processUnregistering(address, address, string memory, bytes calldata) external pure override {}
+    function configure(bytes calldata) external pure override {}
+}

--- a/test/username/Username.t.sol
+++ b/test/username/Username.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import "forge-std/Test.sol";
+import {Username, IUsernameRule} from "../../contracts/primitives/username/Username.sol";
+import {
+    AddressBasedAccessControl,
+    IRoleBasedAccessControl
+} from "../../contracts/primitives/access-control/AddressBasedAccessControl.sol";
+import {MockUsernameRule} from "../mock/MockUsernameRule.sol";
+
+contract UsernameTest is Test {
+    Username private username;
+    AddressBasedAccessControl public addressBasedAccessControl;
+    MockUsernameRule public mockUsernameRule;
+
+    address public owner = address(1);
+    address public adminSetRules = address(2);
+    address public adminChangeAccessControl = address(3);
+    address public user1 = address(4);
+    address public user2 = address(5);
+
+    uint256 constant SET_RULES_RID = uint256(keccak256("SET_RULES"));
+    uint256 constant CHANGE_ACCESS_CONTROL_RID = uint256(keccak256("CHANGE_ACCESS_CONTROL"));
+
+    function setUp() public {
+        vm.startPrank(owner);
+        addressBasedAccessControl = new AddressBasedAccessControl(owner);
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(adminSetRules)), SET_RULES_RID, IRoleBasedAccessControl.AccessPermission.GRANTED, ""
+        );
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(adminChangeAccessControl)),
+            CHANGE_ACCESS_CONTROL_RID,
+            IRoleBasedAccessControl.AccessPermission.GRANTED,
+            ""
+        );
+        username = new Username("test", addressBasedAccessControl);
+        mockUsernameRule = new MockUsernameRule();
+        vm.stopPrank();
+
+        vm.prank(adminSetRules);
+        username.setUsernameRules(IUsernameRule(address(mockUsernameRule)));
+    }
+
+    function testInitialState() public {
+        assertEq(username.getNamespace(), "test");
+        assertEq(username.getAccessControl(), address(addressBasedAccessControl));
+        assertEq(username.getUsernameRules(), address(mockUsernameRule));
+    }
+
+    function testSetUsernameRules() public {
+        MockUsernameRule newRule = new MockUsernameRule();
+
+        vm.prank(adminSetRules);
+        username.setUsernameRules(IUsernameRule(address(newRule)));
+
+        assertEq(username.getUsernameRules(), address(newRule));
+    }
+
+    function testCannotSetUsernameRulesWithoutPermission() public {
+        MockUsernameRule newRule = new MockUsernameRule();
+
+        vm.prank(user1);
+        vm.expectRevert();
+        username.setUsernameRules(IUsernameRule(address(newRule)));
+    }
+
+    function testSetAccessControl() public {
+        AddressBasedAccessControl newAccessControl = new AddressBasedAccessControl(owner);
+
+        vm.prank(adminChangeAccessControl);
+        username.setAccessControl(newAccessControl);
+
+        assertEq(username.getAccessControl(), address(newAccessControl));
+    }
+
+    function testCannotSetAccessControlWithoutPermission() public {
+        AddressBasedAccessControl newAccessControl = new AddressBasedAccessControl(owner);
+
+        vm.prank(user1);
+        vm.expectRevert();
+        username.setAccessControl(newAccessControl);
+    }
+
+    function testRegisterUsername() public {
+        vm.prank(user1);
+        username.registerUsername(user1, "alice", "");
+
+        assertEq(username.usernameOf(user1), "alice");
+        assertEq(username.accountOf("alice"), user1);
+    }
+
+    function testCannotRegisterDuplicateUsername() public {
+        vm.prank(user1);
+        username.registerUsername(user1, "alice", "");
+
+        vm.prank(user2);
+        vm.expectRevert();
+        username.registerUsername(user2, "alice", "");
+    }
+
+    function testCannotRegisterMultipleUsernames() public {
+        vm.startPrank(user1);
+        username.registerUsername(user1, "alice", "");
+
+        vm.expectRevert();
+        username.registerUsername(user1, "bob", "");
+        vm.stopPrank();
+    }
+
+    function testUnregisterUsername() public {
+        vm.prank(user1);
+        username.registerUsername(user1, "alice", "");
+
+        vm.prank(user1);
+        username.unregisterUsername("alice", "");
+
+        assertEq(username.usernameOf(user1), "");
+        assertEq(username.accountOf("alice"), address(0));
+    }
+
+    function testCannotUnregisterOthersUsername() public {
+        vm.prank(user1);
+        username.registerUsername(user1, "alice", "");
+
+        vm.prank(user2);
+        vm.expectRevert();
+        username.unregisterUsername("alice", "");
+    }
+}

--- a/test/username/UsernameCharsetRule.t.sol
+++ b/test/username/UsernameCharsetRule.t.sol
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import "forge-std/Test.sol";
+import {UsernameCharsetRule} from "../../contracts/primitives/username/Rules/UsernameCharsetRule.sol";
+import {
+    AddressBasedAccessControl,
+    IRoleBasedAccessControl
+} from "../../contracts/primitives/access-control/AddressBasedAccessControl.sol";
+import {OwnerOnlyAccessControl} from "../../contracts/primitives/access-control/OwnerOnlyAccessControl.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract UsernameCharsetRuleTest is Test {
+    UsernameCharsetRule public rule;
+    AddressBasedAccessControl public addressBasedAccessControl;
+    OwnerOnlyAccessControl public ownerOnlyAccessControl;
+
+    address public owner = address(1);
+    address public adminSkipCharset = address(2);
+    address public adminChangeRuleAccessControl = address(3);
+    address public adminConfigureRule = address(4);
+    address public user1 = address(5);
+
+    uint256 constant SKIP_CHARSET_RID = uint256(keccak256("SKIP_CHARSET"));
+    uint256 constant CHANGE_RULE_ACCESS_CONTROL_RID = uint256(keccak256("CHANGE_RULE_ACCESS_CONTROL"));
+    uint256 constant CONFIGURE_RULE_RID = uint256(keccak256("CONFIGURE_RULE"));
+
+    function setUp() public {
+        vm.startPrank(owner);
+        ownerOnlyAccessControl = new OwnerOnlyAccessControl(owner);
+        addressBasedAccessControl = new AddressBasedAccessControl(owner);
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(adminSkipCharset)), SKIP_CHARSET_RID, IRoleBasedAccessControl.AccessPermission.GRANTED, ""
+        );
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(adminChangeRuleAccessControl)),
+            CHANGE_RULE_ACCESS_CONTROL_RID,
+            IRoleBasedAccessControl.AccessPermission.GRANTED,
+            ""
+        );
+        addressBasedAccessControl.setGlobalAccess(
+            uint256(uint160(adminConfigureRule)),
+            CONFIGURE_RULE_RID,
+            IRoleBasedAccessControl.AccessPermission.GRANTED,
+            ""
+        );
+        // Setup proxy contract to delegate calls to the UsernameCharsetRule contract
+        UsernameCharsetRule usernameCharsetRuleImplementation =
+            new UsernameCharsetRule(OwnerOnlyAccessControl(address(0)), true);
+        ERC1967Proxy usernameCharsetRuleProxy = new ERC1967Proxy(address(usernameCharsetRuleImplementation), "");
+        rule = UsernameCharsetRule(address(usernameCharsetRuleProxy));
+        rule.initiliaze(addressBasedAccessControl);
+        vm.stopPrank();
+    }
+
+    function testChangeRulesWithCorrectRole() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: true,
+            allowLatinLowercase: true,
+            allowLatinUppercase: false,
+            customAllowedCharset: "_",
+            customDisallowedCharset: "",
+            cannotStartWith: "_"
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: false,
+            allowLatinLowercase: false,
+            allowLatinUppercase: false,
+            customAllowedCharset: "",
+            customDisallowedCharset: "",
+            cannotStartWith: ""
+        });
+        data = abi.encode(restrictions, address(0));
+
+        vm.prank(adminConfigureRule);
+        rule.configure(data);
+    }
+
+    function testCannotChangeRulesWithoutPermission() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: true,
+            allowLatinLowercase: true,
+            allowLatinUppercase: false,
+            customAllowedCharset: "_",
+            customDisallowedCharset: "",
+            cannotStartWith: "_"
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: false,
+            allowLatinLowercase: false,
+            allowLatinUppercase: false,
+            customAllowedCharset: "",
+            customDisallowedCharset: "",
+            cannotStartWith: ""
+        });
+        data = abi.encode(restrictions, address(0));
+
+        vm.prank(user1);
+        vm.expectRevert();
+        rule.configure(data);
+    }
+
+    function testChangeAccessControlWithCorrectRole() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: false,
+            allowLatinLowercase: false,
+            allowLatinUppercase: false,
+            customAllowedCharset: "",
+            customDisallowedCharset: "",
+            cannotStartWith: ""
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        data = abi.encode(restrictions, address(ownerOnlyAccessControl));
+
+        vm.prank(adminChangeRuleAccessControl);
+        rule.configure(data);
+    }
+
+    function testCannotChangeAccessControlWithoutPermission() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: false,
+            allowLatinLowercase: false,
+            allowLatinUppercase: false,
+            customAllowedCharset: "",
+            customDisallowedCharset: "",
+            cannotStartWith: ""
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        data = abi.encode(restrictions, address(ownerOnlyAccessControl));
+
+        vm.prank(user1);
+        vm.expectRevert();
+        rule.configure(data);
+    }
+
+    function testProcessRegisteringValidCharset() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: true,
+            allowLatinLowercase: true,
+            allowLatinUppercase: false,
+            customAllowedCharset: "_",
+            customDisallowedCharset: "",
+            cannotStartWith: "_"
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        rule.processRegistering(address(this), address(this), "valid_username123", "");
+    }
+
+    function testCannotProcessRegisteringInvalidStartChar() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: true,
+            allowLatinLowercase: true,
+            allowLatinUppercase: false,
+            customAllowedCharset: "_",
+            customDisallowedCharset: "",
+            cannotStartWith: "_"
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        vm.expectRevert("UsernameCharsetRule: Username cannot start with specified character");
+        rule.processRegistering(address(this), address(this), "_invalid_start", "");
+    }
+
+    function testCannotProcessRegisteringDisallowedChar() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: true,
+            allowLatinLowercase: true,
+            allowLatinUppercase: false,
+            customAllowedCharset: "",
+            customDisallowedCharset: "$",
+            cannotStartWith: ""
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        vm.expectRevert("UsernameCharsetRule: Username contains disallowed character");
+        rule.processRegistering(address(this), address(this), "invalid$username", "");
+    }
+
+    function testCannotProcessRegisteringUppercaseNotAllowed() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: true,
+            allowLatinLowercase: true,
+            allowLatinUppercase: false,
+            customAllowedCharset: "",
+            customDisallowedCharset: "",
+            cannotStartWith: ""
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        vm.expectRevert("UsernameCharsetRule: Username cannot contain uppercase latin characters");
+        rule.processRegistering(address(this), address(this), "InvalidUppercase", "");
+    }
+
+    function testCannotProcessRegisteringCustomAllowedCharset() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: false,
+            allowLatinLowercase: false,
+            allowLatinUppercase: false,
+            customAllowedCharset: "!@#",
+            customDisallowedCharset: "",
+            cannotStartWith: ""
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        rule.processRegistering(address(this), address(this), "!@#", "");
+
+        vm.expectRevert("UsernameCharsetRule: Username cannot contain lowercase latin characters");
+        rule.processRegistering(address(this), address(this), "invalid", "");
+    }
+
+    function testSkipCharsetCheck() public {
+        UsernameCharsetRule.CharsetRestrictions memory restrictions = UsernameCharsetRule.CharsetRestrictions({
+            allowNumeric: false,
+            allowLatinLowercase: false,
+            allowLatinUppercase: false,
+            customAllowedCharset: "",
+            customDisallowedCharset: "",
+            cannotStartWith: ""
+        });
+        bytes memory data = abi.encode(restrictions, address(0));
+        vm.prank(owner);
+        rule.configure(data);
+
+        // This should pass despite not meeting the charset restrictions
+        rule.processRegistering(owner, address(this), "skipped_check123", "");
+    }
+}

--- a/test/username/UsernameLengthRule.t.sol
+++ b/test/username/UsernameLengthRule.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.17;
+
+import "forge-std/Test.sol";
+import {UsernameLengthRule} from "../../contracts/primitives/username/Rules/UsernameLengthRule.sol";
+import {OwnerOnlyAccessControl} from "../../contracts/primitives/access-control/OwnerOnlyAccessControl.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract UsernameLengthRuleTest is Test {
+    UsernameLengthRule public rule;
+    OwnerOnlyAccessControl public ownerOnlyAccessControl;
+
+    address public owner = address(1);
+
+    function setUp() public {
+        vm.startPrank(owner);
+        // Setup proxy contract to delegate calls to the UsernameLengthRule contract
+        UsernameLengthRule usernameLengthRuleImplementation = new UsernameLengthRule();
+        ERC1967Proxy usernameLengthRuleProxy = new ERC1967Proxy(address(usernameLengthRuleImplementation), "");
+        rule = UsernameLengthRule(address(usernameLengthRuleProxy));
+        ownerOnlyAccessControl = new OwnerOnlyAccessControl(owner);
+        vm.stopPrank();
+    }
+
+    function testProcessRegisteringValidLength() public {
+        bytes memory data = abi.encode(3, 10);
+        rule.configure(data);
+
+        rule.processRegistering(address(this), address(this), "user", "");
+        rule.processRegistering(address(this), address(this), "username", "");
+    }
+
+    function testProcessRegisteringUnlimitedMaxLength() public {
+        bytes memory data = abi.encode(3, 0);
+        rule.configure(data);
+
+        rule.processRegistering(address(this), address(this), "verylongusername", "");
+    }
+
+    function testCannotConfigureInvalidMinLength() public {
+        bytes memory data = abi.encode(0, 10);
+        vm.expectRevert();
+        rule.configure(data);
+    }
+
+    function testCannotConfigureInvalidMaxLength() public {
+        bytes memory data = abi.encode(5, 3);
+        vm.expectRevert();
+        rule.configure(data);
+    }
+
+    function testCannotProcessRegisteringTooShort() public {
+        bytes memory data = abi.encode(3, 10);
+        rule.configure(data);
+
+        vm.expectRevert();
+        rule.processRegistering(address(this), address(this), "us", "");
+    }
+
+    function testCannotProcessRegisteringTooLong() public {
+        bytes memory data = abi.encode(3, 10);
+        rule.configure(data);
+
+        vm.expectRevert();
+        rule.processRegistering(address(this), address(this), "verylongusername", "");
+    }
+}


### PR DESCRIPTION
This PR adds unit tests for `username` primitive.
- Complete: Username contract.
- Pending: Rules. It's currently unable to set `_accessControl` internal variable in `UsernamePayToRegisterRule` and `UsernameLengthRule`