### PR TITLE
feat: Post IDs refactored into universal postId + localSequentialId

### DIFF
--- a/abis/Feed.json
+++ b/abis/Feed.json
@@ -33,6 +33,12 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "author",
         "type": "address"
@@ -40,13 +46,7 @@
       {
         "indexed": true,
         "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "sequentialId",
+        "name": "localSequentialId",
         "type": "uint256"
       },
       {
@@ -125,21 +125,15 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "author",
-        "type": "address"
-      },
-      {
-        "indexed": true,
         "internalType": "uint256",
         "name": "postId",
         "type": "uint256"
       },
       {
         "indexed": true,
-        "internalType": "uint256",
-        "name": "universalId",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
       },
       {
         "indexed": false,
@@ -156,21 +150,15 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "author",
-        "type": "address"
-      },
-      {
-        "indexed": true,
         "internalType": "uint256",
         "name": "postId",
         "type": "uint256"
       },
       {
         "indexed": true,
-        "internalType": "uint256",
-        "name": "universalId",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
       },
       {
         "components": [
@@ -487,14 +475,14 @@
       {
         "components": [
           {
-            "internalType": "uint256",
-            "name": "sequentialId",
-            "type": "uint256"
-          },
-          {
             "internalType": "address",
             "name": "author",
             "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "localSequentialId",
+            "type": "uint256"
           },
           {
             "internalType": "address",
@@ -530,11 +518,6 @@
             "internalType": "uint80",
             "name": "lastUpdatedTimestamp",
             "type": "uint80"
-          },
-          {
-            "internalType": "uint256",
-            "name": "universalId",
-            "type": "uint256"
           }
         ],
         "internalType": "struct Post",

--- a/abis/IFeed.json
+++ b/abis/IFeed.json
@@ -17,6 +17,12 @@
     "inputs": [
       {
         "indexed": true,
+        "internalType": "uint256",
+        "name": "postId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
         "internalType": "address",
         "name": "author",
         "type": "address"
@@ -24,13 +30,7 @@
       {
         "indexed": true,
         "internalType": "uint256",
-        "name": "postId",
-        "type": "uint256"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "sequentialId",
+        "name": "localSequentialId",
         "type": "uint256"
       },
       {
@@ -109,21 +109,15 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "author",
-        "type": "address"
-      },
-      {
-        "indexed": true,
         "internalType": "uint256",
         "name": "postId",
         "type": "uint256"
       },
       {
         "indexed": true,
-        "internalType": "uint256",
-        "name": "universalId",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
       },
       {
         "indexed": false,
@@ -140,21 +134,15 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "author",
-        "type": "address"
-      },
-      {
-        "indexed": true,
         "internalType": "uint256",
         "name": "postId",
         "type": "uint256"
       },
       {
         "indexed": true,
-        "internalType": "uint256",
-        "name": "universalId",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "author",
+        "type": "address"
       },
       {
         "components": [
@@ -471,14 +459,14 @@
       {
         "components": [
           {
-            "internalType": "uint256",
-            "name": "sequentialId",
-            "type": "uint256"
-          },
-          {
             "internalType": "address",
             "name": "author",
             "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "localSequentialId",
+            "type": "uint256"
           },
           {
             "internalType": "address",
@@ -514,11 +502,6 @@
             "internalType": "uint80",
             "name": "lastUpdatedTimestamp",
             "type": "uint80"
-          },
-          {
-            "internalType": "uint256",
-            "name": "universalId",
-            "type": "uint256"
           }
         ],
         "internalType": "struct Post",

--- a/contracts/primitives/feed/Feed.sol
+++ b/contracts/primitives/feed/Feed.sol
@@ -55,12 +55,12 @@ contract Feed is IFeed {
         returns (uint256)
     {
         require(msg.sender == postParams.author);
-        (uint256 postId, uint256 sequentialId) = Core._createPost(postParams);
+        (uint256 postId, uint256 localSequentialId) = Core._createPost(postParams);
         if (address(Core.$storage().feedRules) != address(0)) {
             IFeedRule(Core.$storage().feedRules).processCreatePost(msg.sender, postId, postParams, feedRulesData);
         }
         emit Lens_Feed_PostCreated(
-            postParams.author, postId, sequentialId, postParams, feedRulesData, _getPostTypeId(postParams)
+            postId, postParams.author, localSequentialId, postParams, feedRulesData, _getPostTypeId(postParams)
         );
         return postId;
     }
@@ -85,20 +85,14 @@ contract Feed is IFeed {
         }
         Core._editPost(postId, newPostParams);
         emit Lens_Feed_PostEdited(
-            author,
             postId,
-            Core.$storage().posts[postId].universalId,
+            author,
             newPostParams,
             editPostFeedRulesData,
             postRulesChangeFeedRulesData,
             _getPostTypeId(newPostParams)
         );
     }
-
-    // TODO: How we decided to do moderation (moderator is able to delete spam posts, skipping an author check):
-    /*
-
-    */
 
     function deletePost(uint256 postId, bytes32[] calldata extraDataKeysToDelete, bytes calldata feedRulesData)
         external
@@ -111,8 +105,8 @@ contract Feed is IFeed {
         if (address(Core.$storage().feedRules) != address(0)) {
             IFeedRule(Core.$storage().feedRules).processDeletePost(msg.sender, postId, feedRulesData);
         }
-        uint256 universalId = Core._deletePost(postId, extraDataKeysToDelete);
-        emit Lens_Feed_PostDeleted(author, postId, universalId, feedRulesData);
+        Core._deletePost(postId, extraDataKeysToDelete);
+        emit Lens_Feed_PostDeleted(postId, author, feedRulesData);
     }
 
     function _canDeletePost(address account) internal virtual returns (bool) {
@@ -163,16 +157,15 @@ contract Feed is IFeed {
 
     function getPost(uint256 postId) external view override returns (Post memory) {
         return Post({
-            sequentialId: Core.$storage().posts[postId].sequentialId,
             author: Core.$storage().posts[postId].author,
+            localSequentialId: Core.$storage().posts[postId].localSequentialId,
             source: Core.$storage().posts[postId].source,
             metadataURI: Core.$storage().posts[postId].metadataURI,
             quotedPostIds: Core.$storage().posts[postId].quotedPostIds,
             parentPostIds: Core.$storage().posts[postId].parentPostIds,
             postRules: IPostRule(Core.$storage().posts[postId].postRules),
             creationTimestamp: Core.$storage().posts[postId].creationTimestamp,
-            lastUpdatedTimestamp: Core.$storage().posts[postId].lastUpdatedTimestamp,
-            universalId: Core.$storage().posts[postId].universalId
+            lastUpdatedTimestamp: Core.$storage().posts[postId].lastUpdatedTimestamp
         });
     }
 

--- a/contracts/primitives/feed/FeedCore.sol
+++ b/contracts/primitives/feed/FeedCore.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.17;
 import {PostParams} from "./IFeed.sol";
 
 struct PostStorage {
-    uint256 sequentialId;
     address author;
+    uint256 localSequentialId;
     address source;
     string metadataURI;
     uint256[] quotedPostIds;
@@ -13,7 +13,6 @@ struct PostStorage {
     address postRules;
     uint80 creationTimestamp;
     uint80 lastUpdatedTimestamp;
-    uint256 universalId;
     mapping(bytes32 => bytes) extraData;
 }
 
@@ -52,16 +51,16 @@ library FeedCore {
 
     // Internal functions - Use these functions to be called as an inlined library
 
-    function generatePostId(uint256 sequentialId) internal view returns (uint256) {
-        return uint256(keccak256(abi.encode("evm:", block.chainid, address(this), sequentialId)));
+    function _generatePostId(uint256 localSequentialId) internal view returns (uint256) {
+        return uint256(keccak256(abi.encode("evm:", block.chainid, address(this), localSequentialId)));
     }
 
     function _createPost(PostParams calldata postParams) internal returns (uint256, uint256) {
-        uint256 sequentialId = ++$storage().postCount;
-        uint256 postId = generatePostId(sequentialId);
+        uint256 localSequentialId = ++$storage().postCount;
+        uint256 postId = _generatePostId(localSequentialId);
         PostStorage storage _newPost = $storage().posts[postId];
-        _newPost.sequentialId = sequentialId;
         _newPost.author = postParams.author;
+        _newPost.localSequentialId = localSequentialId;
         _newPost.source = postParams.source;
         _newPost.metadataURI = postParams.metadataURI;
         _newPost.quotedPostIds = postParams.quotedPostIds;
@@ -69,16 +68,15 @@ library FeedCore {
         _newPost.postRules = address(postParams.postRules); // TODO: Probably change to type address in PostParams struct
         _newPost.creationTimestamp = uint80(block.timestamp);
         _newPost.lastUpdatedTimestamp = uint80(block.timestamp);
-        _newPost.universalId = uint256(keccak256(abi.encode("evm:", block.chainid, address(this), postId)));
         for (uint256 i = 0; i < postParams.extraData.length; i++) {
             _newPost.extraData[postParams.extraData[i].key] = postParams.extraData[i].value;
         }
-        return (postId, sequentialId);
+        return (postId, localSequentialId);
     }
 
     function _editPost(uint256 postId, PostParams calldata postParams) internal {
         PostStorage storage _post = $storage().posts[postId];
-        _post.author = postParams.author; // TODO: Author can be changed?
+        _post.author = postParams.author; // TODO: Author can be changed? NO, we should remove that, or add a require
         _post.source = postParams.source; // TODO: Can you edit the source? you might be editing from a diff source than the original source...
         _post.metadataURI = postParams.metadataURI;
         _post.quotedPostIds = postParams.quotedPostIds;
@@ -97,12 +95,15 @@ library FeedCore {
         }
     }
 
-    function _deletePost(uint256 postId, bytes32[] calldata extraDataKeysToDelete) internal returns (uint256) {
-        uint256 universalId = $storage().posts[postId].universalId;
+    function _deletePost(uint256 postId, bytes32[] calldata extraDataKeysToDelete) internal {
         for (uint256 i = 0; i < extraDataKeysToDelete.length; i++) {
             delete $storage().posts[postId].extraData[extraDataKeysToDelete[i]];
         }
         delete $storage().posts[postId];
-        return universalId;
     }
+
+    // TODO: Debate this more. It should be a soft delete, you can reconstruct anyways from tx history.
+    // function _disablePost(uint256 postId) internal {
+    //      $storage().posts[postId].disabled = true;
+    // }
 }

--- a/contracts/primitives/feed/IFeed.sol
+++ b/contracts/primitives/feed/IFeed.sol
@@ -35,8 +35,8 @@ struct PostParams {
 
 // This is a return type (for getters)
 struct Post {
-    uint256 sequentialId;
     address author;
+    uint256 localSequentialId;
     address source;
     string metadataURI;
     uint256[] quotedPostIds;
@@ -44,34 +44,30 @@ struct Post {
     IPostRule postRules;
     uint80 creationTimestamp;
     uint80 lastUpdatedTimestamp;
-    uint256 universalId;
 }
 
 interface IFeed {
     event Lens_Feed_MetadataUriSet(string metadataURI);
 
     event Lens_Feed_PostCreated(
-        address indexed author,
         uint256 indexed postId,
-        uint256 indexed sequentialId,
+        address indexed author,
+        uint256 indexed localSequentialId,
         PostParams postParams,
         bytes feedRulesData,
         uint256 postTypeId
     );
 
     event Lens_Feed_PostEdited(
-        address indexed author,
         uint256 indexed postId,
-        uint256 indexed universalId,
+        address indexed author,
         PostParams newPostParams,
         bytes feedRulesData,
         bytes postRulesChangeFeedRulesData,
         uint256 postTypeId
     );
 
-    event Lens_Feed_PostDeleted(
-        address indexed author, uint256 indexed postId, uint256 indexed universalId, bytes feedRulesData
-    );
+    event Lens_Feed_PostDeleted(uint256 indexed postId, address indexed author, bytes feedRulesData);
 
     event Lens_Feed_RulesSet(address indexed feedRules);
 


### PR DESCRIPTION
Universal PostIDs

postId is now Keccak("evm:", chainId, sequentialPostId)

SequentialId added to post storage