### PR TITLE
feat: remove duplicate CollectActionData import and fix TODO comment style

### DIFF
--- a/contracts/actions/collect/LensCollectedPost.sol
+++ b/contracts/actions/collect/LensCollectedPost.sol
@@ -24,7 +24,7 @@ contract LensCollectedPost is LensERC721, IERC7572 {
     string internal _contractURI;
     address internal immutable _feed;
     uint256 internal immutable _postId;
-    bool internal immutable _isImmutable; // TODO:"" This can be replaced with bytes(_contentURISnapshot).length
+    bool internal immutable _isImmutable; // TODO: This can be replaced with bytes(_contentURISnapshot).length
     address internal immutable _collectAction;
 
     constructor(address feed, uint256 postId, bool isImmutable)

--- a/contracts/actions/collect/SimpleCollectAction.sol
+++ b/contracts/actions/collect/SimpleCollectAction.sol
@@ -6,7 +6,6 @@ import {
     ISimpleCollectAction,
     CollectActionConfigureParams,
     CollectActionExecutionParams,
-    CollectActionData,
     CollectActionData
 } from "./ISimpleCollectAction.sol";
 import {IFeed} from "./../../core/interfaces/IFeed.sol";


### PR DESCRIPTION
Removed the duplicate CollectActionData import from [SimpleCollectAction.sol](https://github.com/lens-protocol/lens-v3/commit/094bd505e08b61fcc163820b0a1ef7d115f8cf9d)
Fixed the TODO comment for consistent formatting and improved readability in [LensCollectedPost.sol](https://github.com/lens-protocol/lens-v3/commit/83e47169c82933042b8ab2252fb53765656a6099)

***Why this is important***
Duplicate imports can cause confusion and lead to compilation errors or warnings in future compiler versions.
Eliminating inconsistencies in code and comments enhances readability and makes the project easier to maintain.