### PR TITLE
fix: Incorrect import of `ZeroAddress` from the `ethers` library

### DIFF
--- a/deploy/deployAux.ts
+++ b/deploy/deployAux.ts
@@ -6,12 +6,12 @@ import {
   verifyPrimitive,
   deployContract,
 } from './utils';
-import { ethers, ZeroAddress } from 'ethers';
+import { ethers } from 'ethers';
 
 const metadataURI = 'https://ipfs.io/ipfs/QmZ';
 
 export const emptySourceStamp = {
-  source: ZeroAddress,
+  source: ethers.constants.AddressZero,
   nonce: 0,
   deadline: 0,
   signature: '0x',


### PR DESCRIPTION
In the ethers library, there is no exported element named `ZeroAddress`. Instead, `ethers.constants.AddressZero` is used to represent the zero address. Attempting to import `ZeroAddress` will result in a compile-time or runtime error, as `ZeroAddress` will not be found in the ethers module.