### PR TITLE
feat: deploy migrations

### DIFF
--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -7,9 +7,14 @@ import { generateEnvFile } from './lensUtils';
 import { deployBeacons, deployProxyAdminLock } from './deployProxyStuff';
 import { getWallet, LOCAL_RICH_WALLETS } from './utils';
 
-export default async function deploy() {
-  const DEPLOYING_FR = false;
+async function deploy() {
+  const DEPLOYING_MIGRATION = Boolean(process.env.DEPLOY_MIGRATION);
+  const DEPLOYING_FR = Boolean(process.env.DEPLOY_FR);
   const deployerAddress = getWallet().address;
+
+  if (DEPLOYING_MIGRATION) {
+    console.log('Deploying migration version...');
+  }
 
   const lockOwner = process.env.PROXY_ADMIN_LOCK_OWNER;
   if (!lockOwner && DEPLOYING_FR) {
@@ -38,7 +43,7 @@ export default async function deploy() {
   }
 
   await deployProxyAdminLock(lockOwner ?? deployerAddress);
-  await deployImplementations();
+  await deployImplementations(DEPLOYING_MIGRATION);
   await deployBeacons(beaconOwner ?? deployerAddress);
   await deployFactories(factoriesProxyOwner ?? LOCAL_RICH_WALLETS[1].address);
   await deployLensPrimitives();
@@ -48,3 +53,14 @@ export default async function deploy() {
   await deployActions(actionHub);
   generateEnvFile();
 }
+
+if (require.main === module) {
+  deploy()
+    .then(() => process.exit(0))
+    .catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+}
+
+export default deploy;

--- a/deploy/deployImplementations.ts
+++ b/deploy/deployImplementations.ts
@@ -1,11 +1,11 @@
 import { deployLensContract, ContractType, ContractInfo } from './lensUtils';
 
-export default async function deployImplementations(): Promise<void> {
+export default async function deployImplementations(DEPLOYING_MIGRATION: boolean): Promise<void> {
   const contracts: ContractInfo[] = [
     { name: 'AppImpl', contractName: 'App', contractType: ContractType.Implementation },
     { name: 'AccountImpl', contractName: 'Account', contractType: ContractType.Implementation },
-    { name: 'FeedImpl', contractName: 'Feed', contractType: ContractType.Implementation },
-    { name: 'GraphImpl', contractName: 'Graph', contractType: ContractType.Implementation },
+    { name: 'FeedImpl', contractName: DEPLOYING_MIGRATION ? 'MigrationFeed' : 'Feed', contractType: ContractType.Implementation },
+    { name: 'GraphImpl', contractName: DEPLOYING_MIGRATION ? 'MigrationGraph' : 'Graph', contractType: ContractType.Implementation },
     { name: 'GroupImpl', contractName: 'Group', contractType: ContractType.Implementation },
     { name: 'NamespaceImpl', contractName: 'Namespace', contractType: ContractType.Implementation },
   ];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,13 @@
   "license": "UNLICENSED. Copyright (C) 2024 Lens Labs. All Rights Reserved.",
   "scripts": {
     "deploy": "hardhat deploy-zksync --script deploy.ts",
+    "deploy:fr": "DEPLOY_FR=true hardhat deploy-zksync --script deploy.ts",
+    "deploy:migration": "DEPLOY_MIGRATION=true hardhat deploy-zksync --script deploy.ts",
+    "deploy:migration:fr": "DEPLOY_MIGRATION=true DEPLOY_FR=true hardhat deploy-zksync --script deploy.ts",
     "deploy:local": "hardhat deploy-zksync --script deploy.ts --network inMemoryNode",
+    "deploy:local:fr": "DEPLOY_FR=true hardhat deploy-zksync --script deploy.ts --network inMemoryNode",
+    "deploy:local:migration": "DEPLOY_MIGRATION=true hardhat deploy-zksync --script deploy.ts --network inMemoryNode",
+    "deploy:local:migration:fr": "DEPLOY_MIGRATION=true DEPLOY_FR=true hardhat deploy-zksync --script deploy.ts --network inMemoryNode",
     "interact": "hardhat deploy-zksync --script interact.ts",
     "compile": "hardhat compile",
     "clean": "hardhat clean",


### PR DESCRIPTION
Option to deploy Migration versions of Feed & Graph added to deployment scripts.

Use:
- `yarn deploy:migration`
- `yarn deploy:local:migration`