### PR TITLE
feat: Referrals on Rules and Actions

### DIFF
--- a/contracts/actions/account/TippingAccountAction.sol
+++ b/contracts/actions/account/TippingAccountAction.sol
@@ -17,7 +17,7 @@ contract TippingAccountAction is OwnableMetadataBasedAccountAction, Initializabl
     /// @custom:keccak lens.param.token
     bytes32 public constant PARAM__TIP_TOKEN = 0xee737c77be2981e91c179485406e6d793521b20aca5e2137b6c497949a74bc94;
 
-    constructor(address actionHub) OwnableMetadataBasedAccountAction(actionHub, address(0), "") {
+    constructor() OwnableMetadataBasedAccountAction(address(0), "") {
         _disableInitializers();
     }
 

--- a/contracts/actions/account/TippingAccountAction.sol
+++ b/contracts/actions/account/TippingAccountAction.sol
@@ -5,17 +5,22 @@ pragma solidity ^0.8.26;
 import {OwnableMetadataBasedAccountAction} from "contracts/actions/account/base/OwnableMetadataBasedAccountAction.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {KeyValue} from "contracts/core/types/Types.sol";
+import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
+import {LensPaymentHandler} from "contracts/extensions/fees/LensPaymentHandler.sol";
 
-contract TippingAccountAction is OwnableMetadataBasedAccountAction, Initializable {
+contract TippingAccountAction is LensPaymentHandler, OwnableMetadataBasedAccountAction, Initializable {
     using SafeERC20 for IERC20;
 
     /// @custom:keccak lens.param.amount
     bytes32 constant PARAM__TIP_AMOUNT = 0xc8a06abcb0f2366f32dc2741bdf075c3215e3108918311ec0ac742f1ffd37f49;
     /// @custom:keccak lens.param.token
     bytes32 public constant PARAM__TIP_TOKEN = 0xee737c77be2981e91c179485406e6d793521b20aca5e2137b6c497949a74bc94;
+    /// @custom:keccak lens.param.referrals
+    bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
+
+    uint16 constant REFERRALS_FEE_MAX_BPS = 2000; // 20.00%
 
     constructor() OwnableMetadataBasedAccountAction(address(0), "") {
         _disableInitializers();
@@ -32,15 +37,25 @@ contract TippingAccountAction is OwnableMetadataBasedAccountAction, Initializabl
     {
         address erc20Token;
         uint256 tipAmount;
+        RecipientData[] memory referrals = new RecipientData[](0);
         for (uint256 i = 0; i < params.length; i++) {
             if (params[i].key == PARAM__TIP_AMOUNT) {
                 tipAmount = abi.decode(params[i].value, (uint256));
             } else if (params[i].key == PARAM__TIP_TOKEN) {
                 erc20Token = abi.decode(params[i].value, (address));
+            } else if (params[i].key == PARAM__REFERRALS) {
+                referrals = abi.decode(params[i].value, (RecipientData[]));
             }
         }
         require(tipAmount > 0, Errors.InvalidParameter());
-        IERC20(erc20Token).safeTransferFrom(originalMsgSender, account, tipAmount);
+        _handlePayment({
+            payer: originalMsgSender,
+            token: erc20Token,
+            amount: tipAmount,
+            recipient: account,
+            referrals: referrals,
+            referralFeeBps: REFERRALS_FEE_MAX_BPS
+        });
         return "";
     }
 }

--- a/contracts/actions/account/base/BaseAccountAction.sol
+++ b/contracts/actions/account/base/BaseAccountAction.sol
@@ -8,8 +8,6 @@ import {IAccountAction} from "contracts/extensions/actions/ActionHub.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 
 abstract contract BaseAccountAction is BaseAction, IAccountAction {
-    constructor(address actionHub) BaseAction(actionHub) {}
-
     function configure(address originalMsgSender, address account, KeyValue[] calldata params)
         external
         override

--- a/contracts/actions/account/base/OwnableMetadataBasedAccountAction.sol
+++ b/contracts/actions/account/base/OwnableMetadataBasedAccountAction.sol
@@ -9,7 +9,7 @@ import {BaseAccountAction} from "contracts/actions/account/base/BaseAccountActio
 abstract contract OwnableMetadataBasedAccountAction is BaseAccountAction, Ownable, MetadataBased {
     event Lens_AccountAction_MetadataURISet(string metadataURI);
 
-    constructor(address actionHub, address owner, string memory metadataURI) BaseAccountAction(actionHub) {
+    constructor(address owner, string memory metadataURI) BaseAccountAction() {
         _transferOwnership(owner);
         _setMetadataURI(metadataURI);
     }

--- a/contracts/actions/base/BaseAction.sol
+++ b/contracts/actions/base/BaseAction.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.26;
 
 import {UNIVERSAL_ACTION_MAGIC_VALUE} from "contracts/extensions/actions/ActionHub.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
+import {LENS_CREATE2_ADDRESS, CONTRACT__ACTION_HUB} from "contracts/core/types/Constants.sol";
+import {ILensCreate2} from "contracts/core/upgradeability/LensCreate2.sol";
 
 abstract contract BaseAction {
     address immutable ACTION_HUB;
@@ -16,8 +18,8 @@ abstract contract BaseAction {
         _;
     }
 
-    constructor(address actionHub) {
-        ACTION_HUB = actionHub;
+    constructor() {
+        ACTION_HUB = ILensCreate2(LENS_CREATE2_ADDRESS).getAddress(CONTRACT__ACTION_HUB);
     }
 
     function _configureUniversalAction(address originalMsgSender) internal onlyActionHub returns (bytes memory) {

--- a/contracts/actions/post/TippingPostAction.sol
+++ b/contracts/actions/post/TippingPostAction.sol
@@ -18,7 +18,7 @@ contract TippingPostAction is OwnableMetadataBasedPostAction, Initializable {
     /// @custom:keccak lens.param.token
     bytes32 constant PARAM__TIP_TOKEN = 0xee737c77be2981e91c179485406e6d793521b20aca5e2137b6c497949a74bc94;
 
-    constructor(address actionHub) OwnableMetadataBasedPostAction(actionHub, address(0), "") {
+    constructor() OwnableMetadataBasedPostAction(address(0), "") {
         _disableInitializers();
     }
 

--- a/contracts/actions/post/TippingPostAction.sol
+++ b/contracts/actions/post/TippingPostAction.sol
@@ -5,18 +5,23 @@ pragma solidity ^0.8.26;
 import {OwnableMetadataBasedPostAction} from "contracts/actions/post/base/OwnableMetadataBasedPostAction.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {KeyValue} from "contracts/core/types/Types.sol";
+import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
 import {IFeed} from "contracts/core/interfaces/IFeed.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
+import {LensPaymentHandler} from "contracts/extensions/fees/LensPaymentHandler.sol";
 
-contract TippingPostAction is OwnableMetadataBasedPostAction, Initializable {
+contract TippingPostAction is LensPaymentHandler, OwnableMetadataBasedPostAction, Initializable {
     using SafeERC20 for IERC20;
 
     /// @custom:keccak lens.param.amount
     bytes32 constant PARAM__TIP_AMOUNT = 0xc8a06abcb0f2366f32dc2741bdf075c3215e3108918311ec0ac742f1ffd37f49;
     /// @custom:keccak lens.param.token
     bytes32 constant PARAM__TIP_TOKEN = 0xee737c77be2981e91c179485406e6d793521b20aca5e2137b6c497949a74bc94;
+    /// @custom:keccak lens.param.referrals
+    bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
+
+    uint16 constant REFERRALS_FEE_MAX_BPS = 2000; // 20.00%
 
     constructor() OwnableMetadataBasedPostAction(address(0), "") {
         _disableInitializers();
@@ -33,16 +38,26 @@ contract TippingPostAction is OwnableMetadataBasedPostAction, Initializable {
     {
         address erc20Token;
         uint256 tipAmount;
+        RecipientData[] memory referrals = new RecipientData[](0);
         for (uint256 i = 0; i < params.length; i++) {
             if (params[i].key == PARAM__TIP_AMOUNT) {
                 tipAmount = abi.decode(params[i].value, (uint256));
             } else if (params[i].key == PARAM__TIP_TOKEN) {
                 erc20Token = abi.decode(params[i].value, (address));
+            } else if (params[i].key == PARAM__REFERRALS) {
+                referrals = abi.decode(params[i].value, (RecipientData[]));
             }
         }
         require(tipAmount > 0, Errors.InvalidParameter());
         address account = IFeed(feed).getPostAuthor(postId);
-        IERC20(erc20Token).safeTransferFrom(originalMsgSender, account, tipAmount);
+        _handlePayment({
+            payer: originalMsgSender,
+            token: erc20Token,
+            amount: tipAmount,
+            recipient: account,
+            referrals: referrals,
+            referralFeeBps: REFERRALS_FEE_MAX_BPS
+        });
         return abi.encode(account);
     }
 }

--- a/contracts/actions/post/base/BasePostAction.sol
+++ b/contracts/actions/post/base/BasePostAction.sol
@@ -8,8 +8,6 @@ import {IPostAction} from "contracts/extensions/actions/ActionHub.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 
 abstract contract BasePostAction is BaseAction, IPostAction {
-    constructor(address actionHub) BaseAction(actionHub) {}
-
     function configure(address originalMsgSender, address feed, uint256 postId, KeyValue[] calldata params)
         external
         override

--- a/contracts/actions/post/base/OwnableMetadataBasedPostAction.sol
+++ b/contracts/actions/post/base/OwnableMetadataBasedPostAction.sol
@@ -9,7 +9,7 @@ import {BasePostAction} from "contracts/actions/post/base/BasePostAction.sol";
 abstract contract OwnableMetadataBasedPostAction is BasePostAction, Ownable, MetadataBased {
     event Lens_PostAction_MetadataURISet(string metadataURI);
 
-    constructor(address actionHub, address owner, string memory metadataURI) BasePostAction(actionHub) {
+    constructor(address owner, string memory metadataURI) {
         _transferOwnership(owner);
         _setMetadataURI(metadataURI);
     }

--- a/contracts/actions/post/collect/ISimpleCollectAction.sol
+++ b/contracts/actions/post/collect/ISimpleCollectAction.sol
@@ -12,9 +12,18 @@ import {RecipientData} from "contracts/core/types/Types.sol";
  * @param collectLimit The maximum number of collects for this publication. 0 for no limit.
  * @param token The token associated with this publication.
  * @param currentCollects The current number of collects for this publication.
- * @param recipient Recipient of collect fees.
+ * @param recipients Recipients of collect amount.
  * @param endTimestamp The end timestamp after which collecting is impossible. 0 for no expiry.
+ * @param referralFeeBps The referral fee in basis points.
+ * @param followerOnlyGraph  The graph that holds the follow relations that restrict who can collect this post.
  * @param collectionAddress The address of the collectible ERC721 contract.
+ * @param isImmutable If true, it means that:
+ *          - The Post URI is snapshotted at configuration time and cannot be changed later.
+ *          - Collected posts' NFTs remain permanently available.
+ *          - What you see is what you get; editing the Post URI or deleting the post will disable collection.
+ *         Note: This immutability is only guaranteed if the URI is hosted on immutable storage. Mutability inherent
+ *         to the chosen storage technology exceeds the on-chain verification capabilities.
+ * @param isDisabled Whether the collect action is disabled or not.
  */
 struct CollectActionData {
     uint160 amount;
@@ -23,14 +32,12 @@ struct CollectActionData {
     uint96 currentCollects;
     RecipientData[] recipients;
     uint72 endTimestamp;
-    uint16 referralFee;
+    uint16 referralFeeBps;
     address followerOnlyGraph;
     address collectionAddress;
     bool isImmutable;
     bool isDisabled;
 }
-
-uint256 constant BPS_MAX = 10000;
 
 interface ISimpleCollectAction is IPostAction {
     function getCollectActionData(address feed, uint256 postId) external view returns (CollectActionData memory);

--- a/contracts/actions/post/collect/SimpleCollectAction.sol
+++ b/contracts/actions/post/collect/SimpleCollectAction.sol
@@ -2,9 +2,7 @@
 // Copyright (C) 2024 Lens Labs. All Rights Reserved.
 pragma solidity ^0.8.26;
 
-import {
-    ISimpleCollectAction, CollectActionData, BPS_MAX
-} from "contracts/actions/post/collect/ISimpleCollectAction.sol";
+import {ISimpleCollectAction, CollectActionData} from "contracts/actions/post/collect/ISimpleCollectAction.sol";
 import {IFeed} from "contracts/core/interfaces/IFeed.sol";
 import {IGraph} from "contracts/core/interfaces/IGraph.sol";
 import {LensCollectedPost} from "contracts/actions/post/collect/LensCollectedPost.sol";
@@ -13,13 +11,19 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
-import {PARAM__TREASURY} from "contracts/extensions/actions/ActionHub.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
+import {BPS_MAX} from "contracts/core/types/Constants.sol";
+import {LensPaymentHandler} from "contracts/extensions/fees/LensPaymentHandler.sol";
 
 error InvalidSplits();
 error InvalidRecipient();
 
-contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAction, Initializable {
+contract SimpleCollectAction is
+    ISimpleCollectAction,
+    LensPaymentHandler,
+    OwnableMetadataBasedPostAction,
+    Initializable
+{
     using SafeERC20 for IERC20;
 
     struct CollectActionStorage {
@@ -45,8 +49,8 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
     bytes32 constant PARAM__END_TIMESTAMP = 0xe2a4a768f409ba480a321a7d36ec9da16e9eae60a25bb0aeccf334822cc859a8;
     /// @custom:keccak lens.param.recipients
     bytes32 constant PARAM__RECIPIENTS = 0x7f7e01c87d5278dd08505253491cf5d6b30930036f6afa2ae22a980882f2cac1;
-    /// @custom:keccak lens.param.referralFee
-    bytes32 constant PARAM__REFERRAL_FEE = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
+    /// @custom:keccak lens.param.referralFeeBps
+    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
     /// @custom:keccak lens.param.graph
     bytes32 constant PARAM__FOLLOWER_ONLY_GRAPH = 0x7d50408405f482949cd317ab452b66f1104c85a1708ae5be893385b1c898c6d9;
     /// @custom:keccak lens.param.isImmutable
@@ -64,7 +68,7 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
      * @param endTimestamp The end timestamp after which collecting is impossible. 0 for no expiry.
      * @param followerOnlyGraph The graph that holds the follow relations that restrict who can collect this post.
      * @param recipients Recipient(s) of collect fees.
-     * @param referralFee The fee percentage that is distributed to referrals.
+     * @param referralFeeBps The fee percentage that is distributed to referrals.
      * @param isImmutable If true, it means that:
      *          - The Post URI is snapshotted at configuration time and cannot be changed later.
      *          - Collected posts' NFTs remain permanently available.
@@ -78,7 +82,7 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
         address token; /////////// (Optional, but required if amount > 0) Default: address(0)
         uint72 endTimestamp; //////// (Optional) Default: 0
         address followerOnlyGraph; // (Optional) Default: address(0)
-        uint16 referralFee; //////// (Optional) Default: 0
+        uint16 referralFeeBps; //////// (Optional) Default: 0
         RecipientData[] recipients; ////////// (Optional, but required if amount > 0)
         bool isImmutable; /////////// (Optional) Default: true
     }
@@ -95,11 +99,10 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
     struct CollectActionExecutionParams {
         uint256 amountToPay; //// (Optional) Default: 0
         address paymentToken; // (Optional, but required if amount > 0) Default: address(0)
-        RecipientData treasury;
         RecipientData[] referrals;
     }
 
-    constructor(address actionHub) OwnableMetadataBasedPostAction(actionHub, address(0), "") {
+    constructor() OwnableMetadataBasedPostAction(address(0), "") {
         _disableInitializers();
     }
 
@@ -135,7 +138,7 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
                 storedData.collectLimit = configData.collectLimit;
                 storedData.token = configData.token;
                 _updateRecipients(storedData, configData.recipients);
-                storedData.referralFee = configData.referralFee;
+                storedData.referralFeeBps = configData.referralFeeBps;
                 storedData.followerOnlyGraph = configData.followerOnlyGraph;
                 storedData.endTimestamp = configData.endTimestamp;
                 // Immutability cannot be flipped to true.
@@ -199,12 +202,12 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
         if (configData.amount == 0) {
             require(configData.token == address(0), Errors.InvalidParameter());
             require(configData.recipients.length == 0, Errors.InvalidParameter());
-            require(configData.referralFee == 0, Errors.InvalidParameter());
+            require(configData.referralFeeBps == 0, Errors.InvalidParameter());
         } else {
             // We expect token to support ERC-20 interface (call balanceOf and expect it to not revert)
             IERC20(configData.token).balanceOf(address(this));
             require(configData.recipients.length > 0, Errors.InvalidParameter());
-            require(configData.referralFee <= BPS_MAX, Errors.InvalidParameter());
+            require(configData.referralFeeBps <= BPS_MAX, Errors.InvalidParameter());
         }
         if (configData.endTimestamp != 0 && configData.endTimestamp < block.timestamp) {
             revert Errors.InvalidParameter();
@@ -218,15 +221,15 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
 
     function _validateRecipients(RecipientData[] memory recipients, bool allowAddressZero) internal virtual {
         if (recipients.length > 0) {
-            uint16 totalSplit = 0;
+            uint16 totalSplitBps = 0;
             for (uint256 i = 0; i < recipients.length; i++) {
-                require(recipients[i].split > 0, InvalidSplits());
+                require(recipients[i].splitBps > 0, InvalidSplits());
                 if (!allowAddressZero) {
                     require(recipients[i].recipient != address(0), InvalidRecipient());
                 }
-                totalSplit += recipients[i].split;
+                totalSplitBps += recipients[i].splitBps;
             }
-            require(totalSplit == BPS_MAX, InvalidSplits());
+            require(totalSplitBps == BPS_MAX, InvalidSplits());
         }
     }
 
@@ -272,7 +275,7 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
         storedData.collectLimit = configData.collectLimit;
         storedData.token = configData.token;
         _storeRecipients(storedData, configData.recipients);
-        storedData.referralFee = configData.referralFee;
+        storedData.referralFeeBps = configData.referralFeeBps;
         storedData.endTimestamp = configData.endTimestamp;
         storedData.followerOnlyGraph = configData.followerOnlyGraph;
         storedData.collectionAddress = collectionAddress;
@@ -330,60 +333,14 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
         CollectActionExecutionParams memory executionParams
     ) internal virtual {
         CollectActionData storage data = $collectDataStorage().collectData[feed][postId];
-        _validateRecipients(executionParams.referrals, false);
-        uint256 amountLeftAfterTreasury =
-            _transferToTreasury(originalMsgSender, executionParams.treasury, data.token, data.amount);
-        uint256 amountLeftAfterReferrals = _transferToReferrals(
-            originalMsgSender, executionParams.referrals, data.referralFee, data.token, amountLeftAfterTreasury
-        );
-        _transferToRecipients(originalMsgSender, data.recipients, data.token, amountLeftAfterReferrals);
-    }
-
-    function _transferToTreasury(
-        address originalMsgSender,
-        RecipientData memory treasury,
-        address currency,
-        uint256 amount
-    ) internal returns (uint256) {
-        uint256 amountForTreasury = (amount * treasury.split) / BPS_MAX;
-        if (treasury.recipient != address(0) && amountForTreasury > 0) {
-            IERC20(currency).safeTransferFrom(originalMsgSender, treasury.recipient, amountForTreasury);
-        }
-        return amount - amountForTreasury;
-    }
-
-    function _transferToReferrals(
-        address originalMsgSender,
-        RecipientData[] memory referrals,
-        uint256 referralFee,
-        address currency,
-        uint256 amount
-    ) internal returns (uint256) {
-        uint256 totalReferralsAmount = (amount * referralFee) / BPS_MAX;
-        uint256 numberOfReferrals = referrals.length;
-        if (totalReferralsAmount > 0 && numberOfReferrals > 0) {
-            for (uint256 i = 0; i < numberOfReferrals; i++) {
-                uint256 amountForReferral = (totalReferralsAmount * referrals[i].split) / BPS_MAX;
-                if (amountForReferral > 0) {
-                    IERC20(currency).safeTransferFrom(originalMsgSender, referrals[i].recipient, amountForReferral);
-                }
-            }
-        }
-        return numberOfReferrals > 0 ? amount - totalReferralsAmount : amount;
-    }
-
-    function _transferToRecipients(
-        address originalMsgSender,
-        RecipientData[] storage recipients,
-        address currency,
-        uint256 amount
-    ) internal {
-        for (uint256 i = 0; i < recipients.length; i++) {
-            uint256 amountForRecipient = (amount * recipients[i].split) / BPS_MAX;
-            if (amountForRecipient > 0) {
-                IERC20(currency).safeTransferFrom(originalMsgSender, recipients[i].recipient, amountForRecipient);
-            }
-        }
+        _handlePayment({
+            payer: originalMsgSender,
+            token: data.token,
+            amount: data.amount,
+            recipients: data.recipients,
+            referrals: executionParams.referrals,
+            referralFeeBps: data.referralFeeBps
+        });
     }
 
     function _extractConfigurationFromParams(KeyValue[] calldata params)
@@ -396,7 +353,7 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
             collectLimit: 0,
             token: address(0),
             endTimestamp: 0,
-            referralFee: 0,
+            referralFeeBps: 0,
             followerOnlyGraph: address(0),
             recipients: new RecipientData[](0),
             isImmutable: true
@@ -411,8 +368,8 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
                 configData.collectLimit = abi.decode(params[i].value, (uint96));
             } else if (params[i].key == PARAM__END_TIMESTAMP) {
                 configData.endTimestamp = abi.decode(params[i].value, (uint72));
-            } else if (params[i].key == PARAM__REFERRAL_FEE) {
-                configData.referralFee = abi.decode(params[i].value, (uint16));
+            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+                configData.referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__RECIPIENTS) {
                 configData.recipients = abi.decode(params[i].value, (RecipientData[]));
             } else if (params[i].key == PARAM__FOLLOWER_ONLY_GRAPH) {
@@ -429,20 +386,13 @@ contract SimpleCollectAction is ISimpleCollectAction, OwnableMetadataBasedPostAc
         pure
         returns (CollectActionExecutionParams memory)
     {
-        CollectActionExecutionParams memory executionParams = CollectActionExecutionParams({
-            amountToPay: 0,
-            paymentToken: address(0),
-            treasury: RecipientData({recipient: address(0), split: 0}),
-            referrals: new RecipientData[](0)
-        });
-
+        CollectActionExecutionParams memory executionParams =
+            CollectActionExecutionParams({amountToPay: 0, paymentToken: address(0), referrals: new RecipientData[](0)});
         for (uint256 i = 0; i < params.length; i++) {
             if (params[i].key == PARAM__AMOUNT) {
                 executionParams.amountToPay = abi.decode(params[i].value, (uint256));
             } else if (params[i].key == PARAM__TOKEN) {
                 executionParams.paymentToken = abi.decode(params[i].value, (address));
-            } else if (params[i].key == PARAM__TREASURY) {
-                executionParams.treasury = abi.decode(params[i].value, (RecipientData));
             } else if (params[i].key == PARAM__REFERRALS) {
                 executionParams.referrals = abi.decode(params[i].value, (RecipientData[]));
             }

--- a/contracts/actions/post/collect/SimpleCollectAction.sol
+++ b/contracts/actions/post/collect/SimpleCollectAction.sol
@@ -50,12 +50,11 @@ contract SimpleCollectAction is
     /// @custom:keccak lens.param.recipients
     bytes32 constant PARAM__RECIPIENTS = 0x7f7e01c87d5278dd08505253491cf5d6b30930036f6afa2ae22a980882f2cac1;
     /// @custom:keccak lens.param.referralFeeBps
-    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
+    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
     /// @custom:keccak lens.param.graph
     bytes32 constant PARAM__FOLLOWER_ONLY_GRAPH = 0x7d50408405f482949cd317ab452b66f1104c85a1708ae5be893385b1c898c6d9;
     /// @custom:keccak lens.param.isImmutable
     bytes32 constant PARAM__IS_IMMUTABLE = 0x4d1cad3e438026974130ac84979964dd6019eace55216c3de16bc79e36a4c44b;
-
     /// @custom:keccak lens.param.referrals
     bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
 

--- a/contracts/actions/post/collect/SimpleCollectAction.sol
+++ b/contracts/actions/post/collect/SimpleCollectAction.sol
@@ -49,8 +49,8 @@ contract SimpleCollectAction is
     bytes32 constant PARAM__END_TIMESTAMP = 0xe2a4a768f409ba480a321a7d36ec9da16e9eae60a25bb0aeccf334822cc859a8;
     /// @custom:keccak lens.param.recipients
     bytes32 constant PARAM__RECIPIENTS = 0x7f7e01c87d5278dd08505253491cf5d6b30930036f6afa2ae22a980882f2cac1;
-    /// @custom:keccak lens.param.referralFeeBps
-    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
+    /// @custom:keccak lens.param.referralFee
+    bytes32 constant PARAM__REFERRAL_FEE = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
     /// @custom:keccak lens.param.graph
     bytes32 constant PARAM__FOLLOWER_ONLY_GRAPH = 0x7d50408405f482949cd317ab452b66f1104c85a1708ae5be893385b1c898c6d9;
     /// @custom:keccak lens.param.isImmutable
@@ -367,7 +367,7 @@ contract SimpleCollectAction is
                 configData.collectLimit = abi.decode(params[i].value, (uint96));
             } else if (params[i].key == PARAM__END_TIMESTAMP) {
                 configData.endTimestamp = abi.decode(params[i].value, (uint72));
-            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+            } else if (params[i].key == PARAM__REFERRAL_FEE) {
                 configData.referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__RECIPIENTS) {
                 configData.recipients = abi.decode(params[i].value, (RecipientData[]));

--- a/contracts/core/types/Constants.sol
+++ b/contracts/core/types/Constants.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: UNLICENSED
+// Copyright (C) 2024 Lens Labs. All Rights Reserved.
+pragma solidity ^0.8.26;
+
+// 100.00% represented as Basis Points, each Basis Point is 0.01%
+uint256 constant BPS_MAX = 10_000;
+
+address constant LENS_CREATE2_ADDRESS = address(0xC8EA7E2);
+
+/// @custom:keccak lens.contract.ActionHub
+bytes32 constant CONTRACT__ACTION_HUB = 0x914706a68d66e273351f2cd4c1f0c739a3d2d211eb45a40f548eb964a6081fef;
+
+/// @custom:keccak lens.contract.LensFees
+bytes32 constant CONTRACT__LENS_FEES = 0x5072b519d346fa8b5598f9e3ddfc010379305b352a80b2bc6c119eb92ac9a520;

--- a/contracts/core/types/Types.sol
+++ b/contracts/core/types/Types.sol
@@ -47,5 +47,5 @@ struct SourceStamp {
 
 struct RecipientData {
     address recipient;
-    uint16 split; // fraction of BPS_MAX (10 000)
+    uint16 splitBps; // In Basis Points, each Basis Point represents 0.01%
 }

--- a/contracts/core/upgradeability/LensCreate2.sol
+++ b/contracts/core/upgradeability/LensCreate2.sol
@@ -10,7 +10,19 @@ import {Errors} from "contracts/core/types/Errors.sol";
 
 contract FixedImplementationContract {}
 
-contract LensCreate2 {
+interface ILensCreate2 {
+    function getAddress(bytes32 salt) external view returns (address);
+
+    function createTransparentUpgradeableProxy(
+        bytes32 salt,
+        address implementation,
+        address proxyAdmin,
+        bytes calldata initializerCall,
+        address expectedAddress
+    ) external returns (address);
+}
+
+contract LensCreate2 is ILensCreate2 {
     address public immutable FIXED_IMPLEMENTATION;
     bytes32 public immutable PROXY_BYTECODE_HASH;
     bytes32 public immutable SENDER_BYTES;
@@ -30,7 +42,7 @@ contract LensCreate2 {
         CONSTRUCTOR_ARGS_HASH = keccak256(abi.encode(FIXED_IMPLEMENTATION, address(this), ""));
     }
 
-    function getAddress(bytes32 salt) external view returns (address) {
+    function getAddress(bytes32 salt) external view override returns (address) {
         return address(
             uint160(
                 uint256(
@@ -48,7 +60,7 @@ contract LensCreate2 {
         address proxyAdmin,
         bytes calldata initializerCall,
         address expectedAddress
-    ) external returns (address) {
+    ) external override returns (address) {
         ITransparentUpgradeableProxy proxy = ITransparentUpgradeableProxy(
             address(new TransparentUpgradeableProxy{salt: salt}(FIXED_IMPLEMENTATION, address(this), ""))
         );

--- a/contracts/extensions/actions/ActionHub.sol
+++ b/contracts/extensions/actions/ActionHub.sol
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Lens Labs. All Rights Reserved.
 pragma solidity ^0.8.26;
 
-import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
+import {KeyValue} from "contracts/core/types/Types.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {IFeed} from "contracts/core/interfaces/IFeed.sol";
 import {SourceStampBased} from "contracts/core/base/SourceStampBased.sol";
@@ -41,10 +41,6 @@ interface IAccountAction {
 
 /// @custom:keccak lens.constant.UniversalAction
 bytes32 constant UNIVERSAL_ACTION_MAGIC_VALUE = 0xa12c06eea999f2a08fb2bd50e396b2a286921eebbda81fb45a0adcf13afb18ef;
-
-// TODO: Move this to some common place
-/// @custom:keccak lens.constant.treasury
-bytes32 constant PARAM__TREASURY = 0xbb11f745546ed845ede751a92f918c8aaa9f3452fe531827e1098a36ed92ac50;
 
 contract ActionHub is SourceStampBased {
     event Lens_ActionHub_PostAction_Universal(address indexed action);
@@ -181,14 +177,6 @@ contract ActionHub is SourceStampBased {
         }
     }
 
-    address immutable LENS_TREASURY_ADDRESS;
-    uint16 immutable LENS_TREASURY_FEE;
-
-    constructor(address treasury, uint16 treasuryFee) {
-        LENS_TREASURY_ADDRESS = treasury;
-        LENS_TREASURY_FEE = treasuryFee;
-    }
-
     function signalUniversalPostAction(address action) external {
         bytes memory returnData = IPostAction(action).configure(address(0), address(0), 0, new KeyValue[](0));
         require(abi.decode(returnData, (bytes32)) == UNIVERSAL_ACTION_MAGIC_VALUE, Errors.UnexpectedContractImpl());
@@ -222,13 +210,10 @@ contract ActionHub is SourceStampBased {
         returns (bytes memory)
     {
         require($postActionStatus()[action][feed][postId].isDisabled == false, Errors.Disabled());
-        KeyValue[] memory paramsWithTreasury = _embedTreasury(params);
-        bytes memory returnData = IPostAction(action).execute(msg.sender, feed, postId, paramsWithTreasury);
+        bytes memory returnData = IPostAction(action).execute(msg.sender, feed, postId, params);
         address postAuthor = IFeed(feed).getPostAuthor(postId);
         address source = _processSourceStamp(params);
-        emit Lens_ActionHub_PostAction_Executed(
-            action, msg.sender, feed, postId, postAuthor, source, paramsWithTreasury, returnData
-        );
+        emit Lens_ActionHub_PostAction_Executed(action, msg.sender, feed, postId, postAuthor, source, params, returnData);
         return returnData;
     }
 
@@ -289,10 +274,9 @@ contract ActionHub is SourceStampBased {
         returns (bytes memory)
     {
         require($accountActionStatus()[action][account].isDisabled == false, Errors.Disabled());
-        KeyValue[] memory paramsWithTreasury = _embedTreasury(params);
-        bytes memory returnData = IAccountAction(action).execute(msg.sender, account, paramsWithTreasury);
+        bytes memory returnData = IAccountAction(action).execute(msg.sender, account, params);
         address source = _processSourceStamp(params);
-        emit Lens_ActionHub_AccountAction_Executed(action, msg.sender, account, source, paramsWithTreasury, returnData);
+        emit Lens_ActionHub_AccountAction_Executed(action, msg.sender, account, source, params, returnData);
         return returnData;
     }
 
@@ -320,26 +304,5 @@ contract ActionHub is SourceStampBased {
         address source = _processSourceStamp(params);
         emit Lens_ActionHub_AccountAction_Enabled(action, msg.sender, account, source, params, returnData);
         return returnData;
-    }
-
-    function _embedTreasury(KeyValue[] memory params) internal view returns (KeyValue[] memory) {
-        KeyValue[] memory paramsWithTreasury = new KeyValue[](params.length + 1);
-        for (uint256 i = 0; i < params.length; i++) {
-            require(params[i].key != PARAM__TREASURY, Errors.InvalidParameter());
-            paramsWithTreasury[i] = params[i];
-        }
-        paramsWithTreasury[params.length] = KeyValue({
-            key: PARAM__TREASURY,
-            value: abi.encode(RecipientData({recipient: LENS_TREASURY_ADDRESS, split: LENS_TREASURY_FEE}))
-        });
-        return paramsWithTreasury;
-    }
-
-    function getTreasury() external view returns (address) {
-        return LENS_TREASURY_ADDRESS;
-    }
-
-    function getTreasuryFee() external view returns (uint16) {
-        return LENS_TREASURY_FEE;
     }
 }

--- a/contracts/extensions/fees/LensFees.sol
+++ b/contracts/extensions/fees/LensFees.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: UNLICENSED
+// Copyright (C) 2024 Lens Labs. All Rights Reserved.
+pragma solidity ^0.8.26;
+
+struct LensFeesData {
+    address treasuryAddress;
+    uint16 treasuryFeeBps;
+}
+
+interface ILensFees {
+    function getTreasuryAddress() external view returns (address);
+
+    function getTreasuryFeeBps() external view returns (uint16);
+
+    function getLensFeesData() external view returns (LensFeesData memory);
+}
+
+contract LensFees is ILensFees {
+    address internal immutable LENS_TREASURY_ADDRESS;
+    uint16 internal immutable LENS_TREASURY_FEE_BPS;
+
+    function getTreasuryAddress() external view override returns (address) {
+        return LENS_TREASURY_ADDRESS;
+    }
+
+    function getTreasuryFeeBps() external view override returns (uint16) {
+        return LENS_TREASURY_FEE_BPS;
+    }
+
+    function getLensFeesData() external view override returns (LensFeesData memory) {
+        return LensFeesData(LENS_TREASURY_ADDRESS, LENS_TREASURY_FEE_BPS);
+    }
+}

--- a/contracts/extensions/fees/LensPaymentHandler.sol
+++ b/contracts/extensions/fees/LensPaymentHandler.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: UNLICENSED
+// Copyright (C) 2024 Lens Labs. All Rights Reserved.
+pragma solidity ^0.8.26;
+
+import {ILensFees, LensFeesData} from "contracts/extensions/fees/LensFees.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {LENS_CREATE2_ADDRESS, CONTRACT__LENS_FEES, BPS_MAX} from "contracts/core/types/Constants.sol";
+import {RecipientData} from "contracts/core/types/Types.sol";
+import {ILensCreate2} from "contracts/core/upgradeability/LensCreate2.sol";
+
+abstract contract LensPaymentHandler {
+    using SafeERC20 for IERC20;
+
+    address immutable LENS_FEES;
+
+    constructor() {
+        LENS_FEES = ILensCreate2(LENS_CREATE2_ADDRESS).getAddress(CONTRACT__LENS_FEES);
+    }
+
+    function _handlePayment(
+        address payer,
+        address token,
+        uint256 amount,
+        RecipientData[] memory recipients,
+        RecipientData[] memory referrals,
+        uint16 referralFeeBps
+    ) internal virtual {
+        uint256 remainingAmount = _processTreasuryFee(payer, token, amount);
+        remainingAmount = _processReferralFees(payer, token, remainingAmount, referrals, referralFeeBps);
+        _processRecipients(payer, token, remainingAmount, recipients);
+    }
+
+    function _handlePayment(
+        address payer,
+        address token,
+        uint256 amount,
+        address recipient,
+        RecipientData[] memory referrals,
+        uint16 referralFeeBps
+    ) internal virtual {
+        uint256 remainingAmount = _processTreasuryFee(payer, token, amount);
+        remainingAmount = _processReferralFees(payer, token, remainingAmount, referrals, referralFeeBps);
+        _processRecipient(payer, token, remainingAmount, recipient);
+    }
+
+    function _processTreasuryFee(address payer, address token, uint256 amount) internal virtual returns (uint256) {
+        LensFeesData memory lensFees = ILensFees(LENS_FEES).getLensFeesData();
+        uint256 amountForTreasury = (amount * lensFees.treasuryFeeBps) / BPS_MAX;
+        if (lensFees.treasuryAddress != address(0) && amountForTreasury > 0) {
+            IERC20(token).safeTransferFrom(payer, lensFees.treasuryAddress, amountForTreasury);
+        }
+        return amount - amountForTreasury;
+    }
+
+    function _processReferralFees(
+        address payer,
+        address token,
+        uint256 amount,
+        RecipientData[] memory referrals,
+        uint16 referralFeeBps
+    ) internal virtual returns (uint256) {
+        uint256 totalAmountForReferrals = (amount * referralFeeBps) / BPS_MAX;
+        if (totalAmountForReferrals == 0 || referrals.length == 0) {
+            return amount;
+        }
+        uint16 accumulatedSplitBps;
+        for (uint256 i = 0; i < referrals.length; i++) {
+            uint256 amountForReferral = (totalAmountForReferrals * referrals[i].splitBps) / BPS_MAX;
+            accumulatedSplitBps += referrals[i].splitBps;
+            if (amountForReferral > 0) {
+                IERC20(token).safeTransferFrom(payer, referrals[i].recipient, amountForReferral);
+            }
+        }
+        require(accumulatedSplitBps <= BPS_MAX);
+        return amount - totalAmountForReferrals;
+    }
+
+    function _processRecipient(address payer, address token, uint256 amount, address recipient) internal virtual {
+        if (amount > 0) {
+            IERC20(token).safeTransferFrom(payer, recipient, amount);
+        }
+    }
+
+    function _processRecipients(address payer, address token, uint256 amount, RecipientData[] memory recipients)
+        internal
+        virtual
+    {
+        for (uint256 i = 0; i < recipients.length; i++) {
+            uint256 amountForRecipient = (amount * recipients[i].splitBps) / BPS_MAX;
+            if (amountForRecipient > 0) {
+                IERC20(token).safeTransferFrom(payer, recipients[i].recipient, amountForRecipient);
+            }
+        }
+    }
+}

--- a/contracts/rules/base/SimplePaymentRule.sol
+++ b/contracts/rules/base/SimplePaymentRule.sol
@@ -7,8 +7,10 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {OwnableMetadataBasedRule} from "contracts/rules/base/OwnableMetadataBasedRule.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {TrustBasedRule} from "contracts/rules/base/TrustBasedRule.sol";
+import {LensPaymentHandler} from "contracts/extensions/fees/LensPaymentHandler.sol";
+import {RecipientData} from "contracts/core/types/Types.sol";
 
-abstract contract SimplePaymentRule is TrustBasedRule, OwnableMetadataBasedRule {
+abstract contract SimplePaymentRule is LensPaymentHandler, TrustBasedRule, OwnableMetadataBasedRule {
     using SafeERC20 for IERC20;
 
     /// @custom:keccak lens.param.paymentConfiguration
@@ -35,7 +37,9 @@ abstract contract SimplePaymentRule is TrustBasedRule, OwnableMetadataBasedRule 
     function _beforePayment(
         PaymentConfiguration memory configuration,
         PaymentConfiguration memory expectedConfiguration,
-        address payer
+        address payer,
+        RecipientData[] memory, /* referrals */
+        uint16 /* referralFeeBps */
     ) internal view virtual {
         require(configuration.token == expectedConfiguration.token, Errors.InvalidParameter());
         require(configuration.amount == expectedConfiguration.amount, Errors.InvalidParameter());
@@ -47,9 +51,18 @@ abstract contract SimplePaymentRule is TrustBasedRule, OwnableMetadataBasedRule 
     function _processPayment(
         PaymentConfiguration memory configuration,
         PaymentConfiguration memory expectedConfiguration,
-        address payer
+        address payer,
+        RecipientData[] memory referrals,
+        uint16 referralFeeBps
     ) internal virtual {
-        _beforePayment(configuration, expectedConfiguration, payer);
-        IERC20(configuration.token).safeTransferFrom(payer, configuration.recipient, configuration.amount);
+        _beforePayment(configuration, expectedConfiguration, payer, referrals, referralFeeBps);
+        _handlePayment({
+            payer: payer,
+            token: configuration.token,
+            amount: configuration.amount,
+            recipient: configuration.recipient,
+            referrals: referrals,
+            referralFeeBps: referralFeeBps
+        });
     }
 }

--- a/contracts/rules/feed/SimplePaymentFeedRule.sol
+++ b/contracts/rules/feed/SimplePaymentFeedRule.sol
@@ -24,8 +24,8 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
     bytes32 constant PARAM__ACCESS_CONTROL = 0xcf3b0fab90208e4185bf857e0f943f6672abffb7d0898e0750beeeb991ae35fa;
     /// @custom:keccak lens.param.referrals
     bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
-    /// @custom:keccak lens.param.referralFeeBps
-    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
+    /// @custom:keccak lens.param.referralFee
+    bytes32 constant PARAM__REFERRAL_FEE = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
 
     /// @custom:keccak lens.storage.SimplePaymentFeedRule
     bytes32 constant STORAGE__SIMPLE_PAYMENT_FEED_RULE =
@@ -127,7 +127,7 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
         for (uint256 i = 0; i < params.length; i++) {
             if (params[i].key == PARAM__ACCESS_CONTROL) {
                 configuration.accessControl = abi.decode(params[i].value, (address));
-            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+            } else if (params[i].key == PARAM__REFERRAL_FEE) {
                 configuration.referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__PAYMENT_CONFIG) {
                 configuration.paymentConfiguration = abi.decode(params[i].value, (PaymentConfiguration));

--- a/contracts/rules/feed/SimplePaymentFeedRule.sol
+++ b/contracts/rules/feed/SimplePaymentFeedRule.sol
@@ -7,10 +7,11 @@ import {IFeedRule} from "contracts/core/interfaces/IFeedRule.sol";
 import {SimplePaymentRule} from "contracts/rules/base/SimplePaymentRule.sol";
 import {AccessControlLib} from "contracts/core/libraries/AccessControlLib.sol";
 import {IAccessControl} from "contracts/core/interfaces/IAccessControl.sol";
-import {KeyValue, RuleChange} from "contracts/core/types/Types.sol";
+import {KeyValue, RuleChange, RecipientData} from "contracts/core/types/Types.sol";
 import {Events} from "contracts/core/types/Events.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
+import {BPS_MAX} from "contracts/core/types/Constants.sol";
 
 contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
     using AccessControlLib for IAccessControl;
@@ -21,6 +22,10 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
 
     /// @custom:keccak lens.param.accessControl
     bytes32 constant PARAM__ACCESS_CONTROL = 0xcf3b0fab90208e4185bf857e0f943f6672abffb7d0898e0750beeeb991ae35fa;
+    /// @custom:keccak lens.param.referrals
+    bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
+    /// @custom:keccak lens.param.referralFeeBps
+    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
 
     /// @custom:keccak lens.storage.SimplePaymentFeedRule
     bytes32 constant STORAGE__SIMPLE_PAYMENT_FEED_RULE =
@@ -28,6 +33,7 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
 
     struct Configuration {
         address accessControl;
+        uint16 referralFeeBps;
         PaymentConfiguration paymentConfiguration;
     }
 
@@ -53,6 +59,7 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
     function configure(bytes32 configSalt, KeyValue[] calldata ruleParams) external override {
         Configuration memory configuration = _extractConfigurationFromParams(ruleParams);
         configuration.accessControl.verifyHasAccessFunction();
+        require(configuration.referralFeeBps <= BPS_MAX, Errors.InvalidParameter());
         _validatePaymentConfiguration(configuration.paymentConfiguration);
         $storage().configuration[msg.sender][configSalt] = configuration;
     }
@@ -68,7 +75,9 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
             $storage().configuration[msg.sender][configSalt].accessControl,
             $storage().configuration[msg.sender][configSalt].paymentConfiguration,
             _extractPaymentConfigurationFromParams(ruleParams),
-            postParams.author
+            postParams.author,
+            _extractReferralsFromParams(ruleParams),
+            $storage().configuration[msg.sender][configSalt].referralFeeBps
         );
     }
 
@@ -104,10 +113,12 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
         address accessControl,
         PaymentConfiguration memory paymentConfiguration,
         PaymentConfiguration memory expectedPaymentConfiguration,
-        address payer
+        address payer,
+        RecipientData[] memory referrals,
+        uint16 referralFeeBps
     ) internal {
         if (!accessControl.hasAccess(payer, PID__SKIP_PAYMENT)) {
-            _processPayment(paymentConfiguration, expectedPaymentConfiguration, payer);
+            _processPayment(paymentConfiguration, expectedPaymentConfiguration, payer, referrals, referralFeeBps);
         }
     }
 
@@ -116,6 +127,8 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
         for (uint256 i = 0; i < params.length; i++) {
             if (params[i].key == PARAM__ACCESS_CONTROL) {
                 configuration.accessControl = abi.decode(params[i].value, (address));
+            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+                configuration.referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__PAYMENT_CONFIG) {
                 configuration.paymentConfiguration = abi.decode(params[i].value, (PaymentConfiguration));
             }
@@ -136,5 +149,16 @@ contract SimplePaymentFeedRule is SimplePaymentRule, Initializable, IFeedRule {
             }
         }
         return paymentConfiguration;
+    }
+
+    function _extractReferralsFromParams(KeyValue[] calldata params) internal pure returns (RecipientData[] memory) {
+        RecipientData[] memory referrals = new RecipientData[](0);
+        for (uint256 i = 0; i < params.length; i++) {
+            if (params[i].key == PARAM__REFERRALS) {
+                referrals = abi.decode(params[i].value, (RecipientData[]));
+                break;
+            }
+        }
+        return referrals;
     }
 }

--- a/contracts/rules/follow/SimplePaymentFollowRule.sol
+++ b/contracts/rules/follow/SimplePaymentFollowRule.sol
@@ -4,11 +4,16 @@ pragma solidity ^0.8.26;
 
 import {IFollowRule} from "contracts/core/interfaces/IFollowRule.sol";
 import {SimplePaymentRule} from "contracts/rules/base/SimplePaymentRule.sol";
-import {KeyValue} from "contracts/core/types/Types.sol";
+import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
 
 contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRule {
+    /// @custom:keccak lens.param.referrals
+    bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
+    /// @custom:keccak lens.param.referralFeeBps
+    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
+
     /// @custom:keccak lens.storage.SimplePaymentFollowRule
     bytes32 constant STORAGE__SIMPLE_PAYMENT_FOLLOW_RULE =
         0x40d861d20f0413c082c732a37b8aa34f7a2abf2d3b8a62e3868805a8505f8fd5;
@@ -49,7 +54,9 @@ contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRul
         _processPayment({
             configuration: $storage().paymentConfiguration[msg.sender][accountToFollow][configSalt],
             expectedConfiguration: _extractPaymentConfigurationFromParams(ruleParams),
-            payer: followerAccount
+            payer: followerAccount,
+            referrals: new RecipientData[](0), // TODO: Implement!
+            referralFeeBps: 0 // TODO: Implement!
         });
     }
 

--- a/contracts/rules/follow/SimplePaymentFollowRule.sol
+++ b/contracts/rules/follow/SimplePaymentFollowRule.sol
@@ -11,8 +11,8 @@ import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
 contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRule {
     /// @custom:keccak lens.param.referrals
     bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
-    /// @custom:keccak lens.param.referralFeeBps
-    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
+    /// @custom:keccak lens.param.referralFee
+    bytes32 constant PARAM__REFERRAL_FEE = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
 
     /// @custom:keccak lens.storage.SimplePaymentFollowRule
     bytes32 constant STORAGE__SIMPLE_PAYMENT_FOLLOW_RULE =

--- a/contracts/rules/follow/SimplePaymentFollowRule.sol
+++ b/contracts/rules/follow/SimplePaymentFollowRule.sol
@@ -7,6 +7,7 @@ import {SimplePaymentRule} from "contracts/rules/base/SimplePaymentRule.sol";
 import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
+import {BPS_MAX} from "contracts/core/types/Constants.sol";
 
 contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRule {
     /// @custom:keccak lens.param.referrals
@@ -18,9 +19,14 @@ contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRul
     bytes32 constant STORAGE__SIMPLE_PAYMENT_FOLLOW_RULE =
         0x40d861d20f0413c082c732a37b8aa34f7a2abf2d3b8a62e3868805a8505f8fd5;
 
+    struct Configuration {
+        PaymentConfiguration paymentConfiguration;
+        uint16 referralFeeBps;
+    }
+
     struct Storage {
-        mapping(address graph => mapping(address account => mapping(bytes32 configSalt => PaymentConfiguration config)))
-            paymentConfiguration;
+        mapping(address graph => mapping(address account => mapping(bytes32 configSalt => Configuration config)))
+            configuration;
     }
 
     function $storage() private pure returns (Storage storage _storage) {
@@ -38,9 +44,12 @@ contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRul
     }
 
     function configure(bytes32 configSalt, address account, KeyValue[] calldata ruleParams) external override {
-        PaymentConfiguration memory paymentConfiguration = _extractPaymentConfigurationFromParams(ruleParams);
-        _validatePaymentConfiguration(paymentConfiguration);
-        $storage().paymentConfiguration[msg.sender][account][configSalt] = paymentConfiguration;
+        Configuration memory configuration = _extractConfigurationFromParams(ruleParams);
+        require(configuration.referralFeeBps <= BPS_MAX, Errors.InvalidParameter());
+        _validatePaymentConfiguration(configuration.paymentConfiguration);
+        $storage().configuration[msg.sender][account][configSalt].paymentConfiguration =
+            configuration.paymentConfiguration;
+        $storage().configuration[msg.sender][account][configSalt].referralFeeBps = configuration.referralFeeBps;
     }
 
     function processFollow(
@@ -52,12 +61,24 @@ contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRul
         KeyValue[] calldata ruleParams
     ) external override {
         _processPayment({
-            configuration: $storage().paymentConfiguration[msg.sender][accountToFollow][configSalt],
+            configuration: $storage().configuration[msg.sender][accountToFollow][configSalt].paymentConfiguration,
             expectedConfiguration: _extractPaymentConfigurationFromParams(ruleParams),
             payer: followerAccount,
-            referrals: new RecipientData[](0), // TODO: Implement!
-            referralFeeBps: 0 // TODO: Implement!
+            referrals: _extractReferralsFromParams(ruleParams),
+            referralFeeBps: $storage().configuration[msg.sender][accountToFollow][configSalt].referralFeeBps
         });
+    }
+
+    function _extractConfigurationFromParams(KeyValue[] calldata params) internal pure returns (Configuration memory) {
+        Configuration memory configuration;
+        for (uint256 i = 0; i < params.length; i++) {
+            if (params[i].key == PARAM__REFERRAL_FEE) {
+                configuration.referralFeeBps = abi.decode(params[i].value, (uint16));
+            } else if (params[i].key == PARAM__PAYMENT_CONFIG) {
+                configuration.paymentConfiguration = abi.decode(params[i].value, (PaymentConfiguration));
+            }
+        }
+        return configuration;
     }
 
     function _extractPaymentConfigurationFromParams(KeyValue[] calldata params)
@@ -71,5 +92,16 @@ contract SimplePaymentFollowRule is SimplePaymentRule, Initializable, IFollowRul
             }
         }
         revert Errors.NotFound();
+    }
+
+    function _extractReferralsFromParams(KeyValue[] calldata params) internal pure returns (RecipientData[] memory) {
+        RecipientData[] memory referrals = new RecipientData[](0);
+        for (uint256 i = 0; i < params.length; i++) {
+            if (params[i].key == PARAM__REFERRALS) {
+                referrals = abi.decode(params[i].value, (RecipientData[]));
+                break;
+            }
+        }
+        return referrals;
     }
 }

--- a/contracts/rules/group/SimplePaymentGroupRule.sol
+++ b/contracts/rules/group/SimplePaymentGroupRule.sol
@@ -6,10 +6,11 @@ import {IGroupRule} from "contracts/core/interfaces/IGroupRule.sol";
 import {SimplePaymentRule} from "contracts/rules/base/SimplePaymentRule.sol";
 import {AccessControlLib} from "contracts/core/libraries/AccessControlLib.sol";
 import {IAccessControl} from "contracts/core/interfaces/IAccessControl.sol";
-import {KeyValue} from "contracts/core/types/Types.sol";
+import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
 import {Events} from "contracts/core/types/Events.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
+import {BPS_MAX} from "contracts/core/types/Constants.sol";
 
 contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule {
     using AccessControlLib for IAccessControl;
@@ -20,6 +21,10 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
 
     /// @custom:keccak lens.param.accessControl
     bytes32 constant PARAM__ACCESS_CONTROL = 0xcf3b0fab90208e4185bf857e0f943f6672abffb7d0898e0750beeeb991ae35fa;
+    /// @custom:keccak lens.param.referrals
+    bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
+    /// @custom:keccak lens.param.referralFeeBps
+    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
 
     /// @custom:keccak lens.storage.SimplePaymentGroupRule
     bytes32 constant STORAGE__SIMPLE_PAYMENT_GROUP_RULE =
@@ -27,6 +32,7 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
 
     struct Configuration {
         address accessControl;
+        uint16 referralFeeBps;
         PaymentConfiguration paymentConfiguration;
     }
 
@@ -52,6 +58,8 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
     function configure(bytes32 configSalt, KeyValue[] calldata ruleParams) external override {
         Configuration memory configuration = _extractConfigurationFromParams(ruleParams);
         configuration.accessControl.verifyHasAccessFunction();
+        require(configuration.referralFeeBps <= BPS_MAX, Errors.InvalidParameter());
+
         _validatePaymentConfiguration(configuration.paymentConfiguration);
         $storage().configuration[msg.sender][configSalt] = configuration;
     }
@@ -67,7 +75,9 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
             $storage().configuration[msg.sender][configSalt].accessControl,
             $storage().configuration[msg.sender][configSalt].paymentConfiguration,
             _extractPaymentConfigurationFromParams(ruleParams),
-            originalMsgSender
+            originalMsgSender,
+            _extractReferralsFromParams(ruleParams),
+            $storage().configuration[msg.sender][configSalt].referralFeeBps
         );
     }
 
@@ -91,7 +101,9 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
             $storage().configuration[msg.sender][configSalt].accessControl,
             $storage().configuration[msg.sender][configSalt].paymentConfiguration,
             _extractPaymentConfigurationFromParams(ruleParams),
-            account
+            account,
+            _extractReferralsFromParams(ruleParams),
+            $storage().configuration[msg.sender][configSalt].referralFeeBps
         );
     }
 
@@ -108,10 +120,12 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
         address accessControl,
         PaymentConfiguration memory paymentConfiguration,
         PaymentConfiguration memory expectedPaymentConfiguration,
-        address payer
+        address payer,
+        RecipientData[] memory referrals,
+        uint16 referralFeeBps
     ) internal {
         if (!accessControl.hasAccess(payer, PID__SKIP_PAYMENT)) {
-            _processPayment(paymentConfiguration, expectedPaymentConfiguration, payer);
+            _processPayment(paymentConfiguration, expectedPaymentConfiguration, payer, referrals, referralFeeBps);
         }
     }
 
@@ -120,6 +134,8 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
         for (uint256 i = 0; i < params.length; i++) {
             if (params[i].key == PARAM__ACCESS_CONTROL) {
                 configuration.accessControl = abi.decode(params[i].value, (address));
+            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+                configuration.referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__PAYMENT_CONFIG) {
                 configuration.paymentConfiguration = abi.decode(params[i].value, (PaymentConfiguration));
             }
@@ -140,5 +156,16 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
             }
         }
         return paymentConfiguration;
+    }
+
+    function _extractReferralsFromParams(KeyValue[] calldata params) internal pure returns (RecipientData[] memory) {
+        RecipientData[] memory referrals = new RecipientData[](0);
+        for (uint256 i = 0; i < params.length; i++) {
+            if (params[i].key == PARAM__REFERRALS) {
+                referrals = abi.decode(params[i].value, (RecipientData[]));
+                break;
+            }
+        }
+        return referrals;
     }
 }

--- a/contracts/rules/group/SimplePaymentGroupRule.sol
+++ b/contracts/rules/group/SimplePaymentGroupRule.sol
@@ -23,8 +23,8 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
     bytes32 constant PARAM__ACCESS_CONTROL = 0xcf3b0fab90208e4185bf857e0f943f6672abffb7d0898e0750beeeb991ae35fa;
     /// @custom:keccak lens.param.referrals
     bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
-    /// @custom:keccak lens.param.referralFeeBps
-    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
+    /// @custom:keccak lens.param.referralFee
+    bytes32 constant PARAM__REFERRAL_FEE = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
 
     /// @custom:keccak lens.storage.SimplePaymentGroupRule
     bytes32 constant STORAGE__SIMPLE_PAYMENT_GROUP_RULE =
@@ -134,7 +134,7 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
         for (uint256 i = 0; i < params.length; i++) {
             if (params[i].key == PARAM__ACCESS_CONTROL) {
                 configuration.accessControl = abi.decode(params[i].value, (address));
-            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+            } else if (params[i].key == PARAM__REFERRAL_FEE) {
                 configuration.referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__PAYMENT_CONFIG) {
                 configuration.paymentConfiguration = abi.decode(params[i].value, (PaymentConfiguration));

--- a/contracts/rules/group/SimplePaymentGroupRule.sol
+++ b/contracts/rules/group/SimplePaymentGroupRule.sol
@@ -59,7 +59,6 @@ contract SimplePaymentGroupRule is SimplePaymentRule, Initializable, IGroupRule 
         Configuration memory configuration = _extractConfigurationFromParams(ruleParams);
         configuration.accessControl.verifyHasAccessFunction();
         require(configuration.referralFeeBps <= BPS_MAX, Errors.InvalidParameter());
-
         _validatePaymentConfiguration(configuration.paymentConfiguration);
         $storage().configuration[msg.sender][configSalt] = configuration;
     }

--- a/contracts/rules/namespace/UsernamePricePerLengthNamespaceRule.sol
+++ b/contracts/rules/namespace/UsernamePricePerLengthNamespaceRule.sol
@@ -24,8 +24,8 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
     bytes32 constant PARAM__ACCESS_CONTROL = 0xcf3b0fab90208e4185bf857e0f943f6672abffb7d0898e0750beeeb991ae35fa;
     /// @custom:keccak lens.param.referrals
     bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
-    /// @custom:keccak lens.param.referralFeeBps
-    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
+    /// @custom:keccak lens.param.referralFee
+    bytes32 constant PARAM__REFERRAL_FEE = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
     /// @custom:keccak lens.param.pricePerLengthConfig
     bytes32 constant PARAM__PRICE_PER_LENGTH = 0xfb5b606f0631eb09d9455c5a3bac25917b3cea6dfc6127937a7a18264219cb27;
 
@@ -175,7 +175,7 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
             } else if (params[i].key == PARAM__PAYMENT_CONFIG) {
                 $storage().configuration[msg.sender][configSalt].defaultConfig =
                     abi.decode(params[i].value, (PaymentConfiguration));
-            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+            } else if (params[i].key == PARAM__REFERRAL_FEE) {
                 $storage().configuration[msg.sender][configSalt].referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__PRICE_PER_LENGTH) {
                 LengthPriceConfig[] memory pricePerLengthConfig = abi.decode(params[i].value, (LengthPriceConfig[]));

--- a/contracts/rules/namespace/UsernamePricePerLengthNamespaceRule.sol
+++ b/contracts/rules/namespace/UsernamePricePerLengthNamespaceRule.sol
@@ -8,8 +8,10 @@ import {INamespaceRule} from "contracts/core/interfaces/INamespaceRule.sol";
 import {AccessControlLib} from "contracts/core/libraries/AccessControlLib.sol";
 import {Events} from "contracts/core/types/Events.sol";
 import {SimplePaymentRule} from "contracts/rules/base/SimplePaymentRule.sol";
-import {KeyValue} from "contracts/core/types/Types.sol";
+import {KeyValue, RecipientData} from "contracts/core/types/Types.sol";
 import {Initializable} from "contracts/core/upgradeability/Initializable.sol";
+import {BPS_MAX} from "contracts/core/types/Constants.sol";
+import {Errors} from "contracts/core/types/Errors.sol";
 
 contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable, INamespaceRule {
     using AccessControlLib for IAccessControl;
@@ -20,6 +22,10 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
 
     /// @custom:keccak lens.param.accessControl
     bytes32 constant PARAM__ACCESS_CONTROL = 0xcf3b0fab90208e4185bf857e0f943f6672abffb7d0898e0750beeeb991ae35fa;
+    /// @custom:keccak lens.param.referrals
+    bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
+    /// @custom:keccak lens.param.referralFeeBps
+    bytes32 constant PARAM__REFERRAL_FEE_BPS = 0x0528211c8ce09d8b4bbf47978d7c2b7901461b28da5f4da81efb3058169ea470;
     /// @custom:keccak lens.param.pricePerLengthConfig
     bytes32 constant PARAM__PRICE_PER_LENGTH = 0xfb5b606f0631eb09d9455c5a3bac25917b3cea6dfc6127937a7a18264219cb27;
 
@@ -29,6 +35,7 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
 
     struct Configuration {
         address accessControl;
+        uint16 referralFeeBps;
         PaymentConfiguration defaultConfig;
         mapping(uint256 => Price) pricePerLength;
     }
@@ -66,6 +73,7 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
     function configure(bytes32 configSalt, KeyValue[] calldata ruleConfigurationParams) external override {
         _extractAndSaveConfigurationFromParams(configSalt, ruleConfigurationParams);
         $storage().configuration[msg.sender][configSalt].accessControl.verifyHasAccessFunction();
+        require($storage().configuration[msg.sender][configSalt].referralFeeBps <= BPS_MAX, Errors.InvalidParameter());
         _validatePaymentConfiguration($storage().configuration[msg.sender][configSalt].defaultConfig);
     }
 
@@ -77,7 +85,13 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
         KeyValue[] calldata, /* primitiveParams */
         KeyValue[] calldata ruleParams
     ) external override {
-        _processPayment(configSalt, originalMsgSender, username, _extractPaymentConfigurationFromParams(ruleParams));
+        _processPayment(
+            configSalt,
+            originalMsgSender,
+            username,
+            _extractPaymentConfigurationFromParams(ruleParams),
+            _extractReferralsFromParams(ruleParams)
+        );
     }
 
     function processRemoval(
@@ -87,7 +101,13 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
         KeyValue[] calldata, /* primitiveParams */
         KeyValue[] calldata ruleParams
     ) external override {
-        _processPayment(configSalt, originalMsgSender, username, _extractPaymentConfigurationFromParams(ruleParams));
+        _processPayment(
+            configSalt,
+            originalMsgSender,
+            username,
+            _extractPaymentConfigurationFromParams(ruleParams),
+            _extractReferralsFromParams(ruleParams)
+        );
     }
 
     function processAssigning(
@@ -98,7 +118,13 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
         KeyValue[] calldata, /* primitiveParams */
         KeyValue[] calldata ruleParams
     ) external override {
-        _processPayment(configSalt, originalMsgSender, username, _extractPaymentConfigurationFromParams(ruleParams));
+        _processPayment(
+            configSalt,
+            originalMsgSender,
+            username,
+            _extractPaymentConfigurationFromParams(ruleParams),
+            _extractReferralsFromParams(ruleParams)
+        );
     }
 
     function processUnassigning(
@@ -109,14 +135,21 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
         KeyValue[] calldata, /* primitiveParams */
         KeyValue[] calldata ruleParams
     ) external override {
-        _processPayment(configSalt, originalMsgSender, username, _extractPaymentConfigurationFromParams(ruleParams));
+        _processPayment(
+            configSalt,
+            originalMsgSender,
+            username,
+            _extractPaymentConfigurationFromParams(ruleParams),
+            _extractReferralsFromParams(ruleParams)
+        );
     }
 
     function _processPayment(
         bytes32 configSalt,
         address payer,
         string calldata username,
-        PaymentConfiguration memory expectedPaymentConfiguration
+        PaymentConfiguration memory expectedPaymentConfiguration,
+        RecipientData[] memory referrals
     ) internal {
         PaymentConfiguration memory paymentConfiguration = $storage().configuration[msg.sender][configSalt].defaultConfig;
         Price memory pricePerLength =
@@ -125,7 +158,13 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
             paymentConfiguration.amount = pricePerLength.price;
         }
         if (!$storage().configuration[msg.sender][configSalt].accessControl.hasAccess(payer, PID__SKIP_PAYMENT)) {
-            _processPayment(paymentConfiguration, expectedPaymentConfiguration, payer);
+            _processPayment(
+                paymentConfiguration,
+                expectedPaymentConfiguration,
+                payer,
+                referrals,
+                $storage().configuration[msg.sender][configSalt].referralFeeBps
+            );
         }
     }
 
@@ -136,6 +175,8 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
             } else if (params[i].key == PARAM__PAYMENT_CONFIG) {
                 $storage().configuration[msg.sender][configSalt].defaultConfig =
                     abi.decode(params[i].value, (PaymentConfiguration));
+            } else if (params[i].key == PARAM__REFERRAL_FEE_BPS) {
+                $storage().configuration[msg.sender][configSalt].referralFeeBps = abi.decode(params[i].value, (uint16));
             } else if (params[i].key == PARAM__PRICE_PER_LENGTH) {
                 LengthPriceConfig[] memory pricePerLengthConfig = abi.decode(params[i].value, (LengthPriceConfig[]));
                 for (uint256 j = 0; j < pricePerLengthConfig.length; j++) {
@@ -159,6 +200,17 @@ contract UsernamePricePerLengthNamespaceRule is SimplePaymentRule, Initializable
             }
         }
         return paymentConfiguration;
+    }
+
+    function _extractReferralsFromParams(KeyValue[] calldata params) internal pure returns (RecipientData[] memory) {
+        RecipientData[] memory referrals = new RecipientData[](0);
+        for (uint256 i = 0; i < params.length; i++) {
+            if (params[i].key == PARAM__REFERRALS) {
+                referrals = abi.decode(params[i].value, (RecipientData[]));
+                break;
+            }
+        }
+        return referrals;
     }
 
     function _validatePaymentConfiguration(PaymentConfiguration memory configuration) internal view virtual override {

--- a/test/upgradeability/LensCreate2.t.sol
+++ b/test/upgradeability/LensCreate2.t.sol
@@ -17,7 +17,7 @@ contract LensCreate2Test is ZkTest {
 
     function setUp() public virtual onlyZkEvm {
         create2 = new LensCreate2();
-        IMPLEMENTATION = address(new ActionHub(address(0x01), 1));
+        IMPLEMENTATION = address(new ActionHub());
         PROXY_ADMIN = makeAddr("PROXY_ADMIN_1");
         INITIALIZER_CALL = "";
         SALT = keccak256("lens.contract.ActionHub");
@@ -70,7 +70,7 @@ contract LensCreate2Test is ZkTest {
     function test_diffImpl_sameAddress() public {
         address deployedContract = create2.createTransparentUpgradeableProxy({
             salt: SALT,
-            implementation: address(new ActionHub(address(0x02), 1)),
+            implementation: address(new ActionHub()),
             proxyAdmin: PROXY_ADMIN,
             initializerCall: INITIALIZER_CALL,
             expectedAddress: EXPECTED_ADDRESS


### PR DESCRIPTION
## How does it work

Except for the tipping actions, which has hardcoded the Referral Fee BPS to 20.00%, the rest of the rules and actions that handle payments expect the following param, which is of type `uint16`:

```solidity
/// @custom:keccak lens.param.referralFee
bytes32 constant PARAM__REFERRAL_FEE = 0x6dff2c1710f2154b19d8cf5d6f7d8f5b3909222c3cdd8801486403e4d423b1b6;
```

This param's value is on "Basis Points" units, which means that each unit represents `0.01%`, so to set `21.33%` you need to pass `2133`. The max value is `10000` which represents `100.00%` and the value cannot be bigger than that. 

If the param is not passed, it will default to 0, so no referral fees set at all.

When you are executing the rule or action, you need to pass the following param, which is of type `RecipientData[]`:

```solidity
/// @custom:keccak lens.param.referrals
bytes32 constant PARAM__REFERRALS = 0x183a1b7fdb9626f5ae4e8cac88ee13cc03b29800d2690f61e2a2566f76d8773f;
```

This param is an array of `RecipientData(address recipient, uint16 splitBps)`, so each element contains the referral recipient address and the percenta of the split that should get (measured in Basis Points as already explained above).

The sum of splitBps' of all referrals cannot go above 10000 (i.e. 100.00%). However, it can be lower than that.

If the param is not passed, it assumes no referrals at all.

The amount to be distributed among referrals is the remaining amount after distributing fees to the Lens Treasury. So, the percentage set on the splitBps for each referral is the percentage over the remaining amount after the Lens Treasury cut is substracted.

---
## Example # 1

_NOTE: This syntax might not compile, it's just to exemplify, so take it as pseudocode._

Let's assume Lens Treasury fees are set to 10.00%.

A rule is configured passing the following custom param:

```solidity
KeyValue({
    key: keccak256("lens.param.referralFee"),
    value: abi.encode(uint16(5000))
})
```
 
This means 50.00% referrals fee.

At some point, that rule is executed and it will do a payment of 100 GHO.

When executed, the following custom param is passed to the rule:

```solidity
KeyValue({
    key: keccak256("lens.param.referrals"),
    value: abi.encode(new RecipientData[](
        {
            recipient: address(0xc0ffee),
            splitBps: uint16(3000)
        },
        {
            recipient: address(0xbeef),
            splitBps: uint16(7000)
        }
    ))
})
```

So, basically, it says it has two referrals, 0xc0ffee, which will get 30.00% of the referral cut, and 0xbeef, which will get the remaining 70.00% of it.

Then, the 100 GHO will be distributed like this:

* 10 GHO to the Lens Treasury (10.00% of the total amount).

From the remaining 90 GHO, 45 GHO will be spent on fees (50.00%), which will go:

* 13.50 GHO to 0xc0ffee (30.00% of remaining amount)
* 31.50 GHO to 0xbeef (70.00% of the remaining amount)
 
And finally, the rest 45 GHO, will go to the recipient definied in the rule (for example, post author, account followed, or whatever was set in the rule).

## Example # 2

Now, let's imagine that we have the same setup that on Example # 1, but instead, the following referrals params are passed to the rule execution:

```solidity
KeyValue({
    key: keccak256("lens.param.referrals"),
    value: abi.encode(new RecipientData[](
        {
            recipient: address(0xc0ffee),
            splitBps: uint16(1000)
        },
        {
            recipient: address(0xbeef),
            splitBps: uint16(1000)
        }
    ))
})
```

In this case, both 0xc0ffee and 0xbeef takes 10.00% each.

So, the 100 GHO are distributed like this:

* 10 GHO to the Lens Treasury

From the 90 GHO remaining, 45 GHO can be distributed on fees (50.00 %). However, the total splitBps sums 20.00% only. So:

* 4.5 GHO goes to 0xbeef (10.00%)
* 4.5 GHO goes to 0xc0ffee (10.00%)

There are 36 GHO available to spend on referrals that were not spend, and will go to the recipient directly.

So the main recipient gets 81 GHO.

This means, let's say an App wants to take 1%, and only 1%, of referrals. When the user configures to share 10% on referrals (to be used on App + discovery-type referrals, e.g. people who re-posted, quoted, etc.), if no discovery-type referrals are passed, the App still can decide to only get 1% to itself and not take the full 10%, giving the rest to the user.