### PR TITLE
fix: canSetMetadataURI should return true for owner

### DIFF
--- a/contracts/extensions/account/Account.sol
+++ b/contracts/extensions/account/Account.sol
@@ -611,8 +611,8 @@ contract Account is
         return _isAccountManager(accountManager);
     }
 
-    function canSetMetadataURI(address accountManager) external view override returns (bool) {
-        return $storage().managerStorage[accountManager].canSetMetadataURI;
+    function canSetMetadataURI(address executor) external view override returns (bool) {
+        return $storage().managerStorage[executor].canSetMetadataURI || executor == owner();
     }
 
     function getAccountManagerPermissions(address accountManager)

--- a/test/extensions/account/Account.t.sol
+++ b/test/extensions/account/Account.t.sol
@@ -1628,10 +1628,42 @@ contract AccountTest2 is FuzzZkTest, BaseDeployments {
         assertEq(accountBalanceBefore + 1 ether, address(account).balance);
     }
 
-    function test_canSetMetadataURI_TrueForOwnerAndManagerWithPermition(address someManager) public {
-        _assumeCanBeAddedAsManager(someManager);
-
+    function test_canSetMetadataURI_TrueForOwner() public {
         assertTrue(account.canSetMetadataURI(owner), "Owner can set metadataURI");
+    }
+
+    function test_canSetMetadataURI_TrueForManagerWithPermission(address someManager) public {
+        _assumeCanBeAddedAsManager(someManager);
+        vm.prank(owner);
+        account.addAccountManager(
+            someManager,
+            AccountManagerPermissions({
+                canExecuteTransactions: false,
+                canTransferTokens: false,
+                canTransferNative: false,
+                canSetMetadataURI: true
+            })
+        );
+        assertTrue(account.canSetMetadataURI(someManager), "Manager with permision can set metadataURI");
+    }
+
+    function test_canSetMetadataURI_FalseForManagerWithoutPermission(address someManager, bool canTransferTokens)
+        public
+    {
+        _assumeCanBeAddedAsManager(someManager);
+        AccountManagerPermissions memory permissions = AccountManagerPermissions({
+            canExecuteTransactions: true,
+            canTransferTokens: canTransferTokens,
+            canTransferNative: canTransferTokens,
+            canSetMetadataURI: false
+        });
+        vm.prank(owner);
+        account.addAccountManager(someManager, permissions);
+        assertFalse(account.canSetMetadataURI(someManager), "Manager without permision cannot set metadataURI");
+    }
+
+    function test_canSetMetadataURI_FalseForRemovedManager(address someManager) public {
+        _assumeCanBeAddedAsManager(someManager);
 
         vm.prank(owner);
         account.addAccountManager(
@@ -1644,6 +1676,17 @@ contract AccountTest2 is FuzzZkTest, BaseDeployments {
             })
         );
         assertTrue(account.canSetMetadataURI(someManager), "Manager with permision can set metadataURI");
+
+        vm.prank(owner);
+        account.removeAccountManager(someManager);
+        assertFalse(account.canSetMetadataURI(someManager), "Removed manager cannot set metadataURI");
+    }
+
+    function test_canSetMetadataURI_FalseForRandomAddress(address randomAddress) public {
+        vm.assume(randomAddress != owner);
+        vm.assume(account.isAccountManager(randomAddress) == false);
+
+        assertFalse(account.canSetMetadataURI(randomAddress), "Random address cannot set metadataURI");
     }
 }
 

--- a/test/extensions/account/Account.t.sol
+++ b/test/extensions/account/Account.t.sol
@@ -1627,6 +1627,24 @@ contract AccountTest2 is FuzzZkTest, BaseDeployments {
 
         assertEq(accountBalanceBefore + 1 ether, address(account).balance);
     }
+
+    function test_canSetMetadataURI_TrueForOwnerAndManagerWithPermition(address someManager) public {
+        _assumeCanBeAddedAsManager(someManager);
+
+        assertTrue(account.canSetMetadataURI(owner), "Owner can set metadataURI");
+
+        vm.prank(owner);
+        account.addAccountManager(
+            someManager,
+            AccountManagerPermissions({
+                canExecuteTransactions: false,
+                canTransferTokens: false,
+                canTransferNative: false,
+                canSetMetadataURI: true
+            })
+        );
+        assertTrue(account.canSetMetadataURI(someManager), "Manager with permision can set metadataURI");
+    }
 }
 
 contract ErrorsTest {


### PR DESCRIPTION
The function `canSetMetadataURI` should return `true` for the account owner, like 'canExecuteTransactions' function does.