### PR TITLE
feat: Namespace createAndAssignUsername allowed for account's controller (Ownable or AC)

### DIFF
--- a/contracts/core/primitives/namespace/Namespace.sol
+++ b/contracts/core/primitives/namespace/Namespace.sol
@@ -156,7 +156,7 @@ contract Namespace is
         RuleProcessingParams[] calldata assigningProcessingParams,
         KeyValue[] memory extraData
     ) external {
-        require(msg.sender == account, Errors.InvalidMsgSender());
+        require(msg.sender == account || _doesMsgSenderControlAccount(account), Errors.InvalidMsgSender());
         uint256 id = _computeId(username);
         _safeMint(account, id);
         $storage().idToUsername[id] = username;

--- a/test/primitives/Namespace.t.sol
+++ b/test/primitives/Namespace.t.sol
@@ -20,6 +20,7 @@ import {Namespace} from "@core/primitives/namespace/Namespace.sol";
 import {Rule} from "@core/types/Types.sol";
 import {RuleExecutionTest} from "test/primitives/rules/RuleExecution.t.sol";
 import {RulesTest} from "test/primitives/rules/Rules.t.sol";
+import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 contract NamespaceTest is RulesTest, BaseDeployments, RuleExecutionTest {
     /// @custom:keccak lens.permission.AssignUsername
@@ -528,7 +529,7 @@ contract NamespaceTest is RulesTest, BaseDeployments, RuleExecutionTest {
         assertEq(namespace.usernameOf(account), localName, "Account should still have the username");
     }
 
-    function test_CreateAndAssignUsername() public {
+    function test_CreateAndAssignUsername_MsgSenderIsAccount() public {
         string memory localName = "satoshi";
         uint256 tokenId = uint256(keccak256(bytes(localName)));
 
@@ -549,6 +550,61 @@ contract NamespaceTest is RulesTest, BaseDeployments, RuleExecutionTest {
         assertEq(LensERC721(address(namespace)).ownerOf(tokenId), account, "Token should be owned by account");
         assertEq(namespace.accountOf(localName), account, "Username should be assigned to account");
         assertEq(namespace.usernameOf(account), localName, "Account should have the username");
+    }
+
+    function test_CreateAndAssignUsername_MsgSenderControlsAccount_ThroughOwnable() public {
+        string memory localName = "satoshi";
+        uint256 tokenId = uint256(keccak256(bytes(localName)));
+
+        // Create account
+        address ownedAccount = address(new MockOwnableERC721Receiver());
+        MockOwnableERC721Receiver(ownedAccount).mockOwner(account);
+
+        // Create and assign username in one operation
+        vm.prank(account);
+        Namespace(address(namespace)).createAndAssignUsername({
+            account: ownedAccount,
+            username: localName,
+            customParams: _emptyKeyValueArray(),
+            unassigningProcessingParams: _emptyRuleProcessingParamsArray(),
+            creationProcessingParams: _emptyRuleProcessingParamsArray(),
+            assigningProcessingParams: _emptyRuleProcessingParamsArray(),
+            extraData: _emptyKeyValueArray()
+        });
+
+        // Verify token ownership and username assignment
+        assertTrue(namespace.exists(localName), "Username should exist");
+        assertEq(LensERC721(address(namespace)).ownerOf(tokenId), ownedAccount, "Token should be owned by account");
+        assertEq(namespace.accountOf(localName), ownedAccount, "Username should be assigned to account");
+        assertEq(namespace.usernameOf(ownedAccount), localName, "Account should have the username");
+    }
+
+    function test_CreateAndAssignUsername_MsgSenderControlsAccount_ThroughAccessControl() public {
+        string memory localName = "satoshi";
+        uint256 tokenId = uint256(keccak256(bytes(localName)));
+
+        // Create account
+        address controlledAccount = address(new MockAccessControllableERC721Receiver());
+        MockAccessControllableERC721Receiver(controlledAccount).mockAccessControl(mockAccessControl);
+        mockAccessControl.mockAccess(account, address(namespace), PID__ASSIGN_USERNAME, true);
+
+        // Create and assign username in one operation
+        vm.prank(account);
+        Namespace(address(namespace)).createAndAssignUsername({
+            account: controlledAccount,
+            username: localName,
+            customParams: _emptyKeyValueArray(),
+            unassigningProcessingParams: _emptyRuleProcessingParamsArray(),
+            creationProcessingParams: _emptyRuleProcessingParamsArray(),
+            assigningProcessingParams: _emptyRuleProcessingParamsArray(),
+            extraData: _emptyKeyValueArray()
+        });
+
+        // Verify token ownership and username assignment
+        assertTrue(namespace.exists(localName), "Username should exist");
+        assertEq(LensERC721(address(namespace)).ownerOf(tokenId), controlledAccount, "Token should be owned by account");
+        assertEq(namespace.accountOf(localName), controlledAccount, "Username should be assigned to account");
+        assertEq(namespace.usernameOf(controlledAccount), localName, "Account should have the username");
     }
 
     function test_CannotAssignToZeroAddress() public {
@@ -1147,6 +1203,17 @@ contract MockOwnable is IOwnable {
     }
 }
 
+contract MockOwnableERC721Receiver is MockOwnable, IERC721Receiver {
+    function onERC721Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        bytes calldata /* data */
+    ) external pure returns (bytes4) {
+        return this.onERC721Received.selector;
+    }
+}
+
 contract MockAccessControllable is IAccessControlled {
     function testMockAccessControllable() public {
         // Prevents being included in the foundry coverage report
@@ -1164,6 +1231,17 @@ contract MockAccessControllable is IAccessControlled {
 
     function mockAccessControl(IAccessControl accessControl) public {
         _accessControl = accessControl;
+    }
+}
+
+contract MockAccessControllableERC721Receiver is MockAccessControllable, IERC721Receiver {
+    function onERC721Received(
+        address, /* operator */
+        address, /* from */
+        uint256, /* tokenId */
+        bytes calldata /* data */
+    ) external pure returns (bytes4) {
+        return this.onERC721Received.selector;
     }
 }
 


### PR DESCRIPTION
### Release procedure
- Upgrade `Namespace` primitive (might worth to merge this with #126 and #128 to do them all in a single upgrade)