### PR TITLE
misc: Warnings cleared & unrechable code supressed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run Tests
         run: forge test -vvv
       - name: Run Tests - ZKsync Environment
-        run: DAPP_TEST_FUZZ_RUNS=5 forge test --zksync -vvv
+        run: DAPP_TEST_FUZZ_RUNS=5 forge test --zksync -vvv --suppress-warnings assemblycreate

--- a/foundry.toml
+++ b/foundry.toml
@@ -20,6 +20,8 @@ evm_version = 'paris'
 #   zkSync's zkEVM has a bigger size limit than classic EVM, and we sometimes use classic foundry for quicker
 #   compilation during development. Also, tests will trigger this warning otherwise too.
 ignored_error_codes = [5740, 5574] 
+# Mask warnings as compilation errors. An easy way to make our CI fail anytime new warnings are introduced.
+deny_warnings = true
 
 [profile.default.fuzz]
 runs = 1024

--- a/foundry.toml
+++ b/foundry.toml
@@ -20,6 +20,8 @@ evm_version = 'paris'
 #   zkSync's zkEVM has a bigger size limit than classic EVM, and we sometimes use classic foundry for quicker
 #   compilation during development. Also, tests will trigger this warning otherwise too.
 ignored_error_codes = [5740, 5574] 
+# Ignore warnings from dependencies.
+ignored_warnings_from = ["lib/", "node_modules/"]
 # Mask warnings as compilation errors. An easy way to make our CI fail anytime new warnings are introduced.
 deny_warnings = true
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,6 +11,15 @@ optimizer = false
 fs_permissions = [{ access = "read", path = "./test/token-uri/expected-svgs/"}, { access = "read", path = "./addressBook.json"}]
 allow_internal_expect_revert = true
 evm_version = 'paris'
+# Ignore the following warnings:
+#
+# - [5740] Unreachable code:
+#   It is triggered by code that is actually reachable because of inheritance. Unlikely to happen in production.
+#
+# - [5574] Size limit:
+#   zkSync's zkEVM has a bigger size limit than classic EVM, and we sometimes use classic foundry for quicker
+#   compilation during development. Also, tests will trigger this warning otherwise too.
+ignored_error_codes = [5740, 5574] 
 
 [profile.default.fuzz]
 runs = 1024

--- a/script/Query.s.sol
+++ b/script/Query.s.sol
@@ -23,11 +23,11 @@ contract Query is Script {
         // Prevents being counted in Foundry Coverage
     }
 
-    function _generatePostId(address author, uint256 authorPostSequentialId) internal view returns (uint256) {
+    function _generatePostId(address author, uint256 authorPostSequentialId) internal pure returns (uint256) {
         return uint256(keccak256(abi.encode("evm:", 271, LENS_GLOBAL_FEED, author, authorPostSequentialId)));
     }
 
-    function run() external {
+    function run() external view {
         console.log("ChainID: ", block.chainid);
         address author = address(0x2aa01F5cDF6403B3b53826e7798790069185bE2F);
         uint256 postCount = IFeed(LENS_GLOBAL_FEED).getPostCount(author);

--- a/test/extensions/account/Account.t.sol
+++ b/test/extensions/account/Account.t.sol
@@ -80,7 +80,7 @@ contract AccountTestBase is FuzzZkTest, BaseDeployments {
         account.changeAllowance(allowanceChanges);
     }
 
-    function _assumeCanBeAddedAsManager(address someManager) internal {
+    function _assumeCanBeAddedAsManager(address someManager) internal view {
         vm.assume(someManager != address(0));
         vm.assume(someManager != owner);
         vm.assume(account.isAccountManager(someManager) == false);
@@ -98,7 +98,7 @@ contract AccountTestBase is FuzzZkTest, BaseDeployments {
         account.addAccountManager(someManager, basicPermissionSet);
     }
 
-    function _assumeEOA(address someAddress) internal {
+    function _assumeEOA(address someAddress) internal view {
         assumeNotForgeAddress(someAddress);
         vm.assume(someAddress.code.length == 0);
         vm.assume(uint160(someAddress) > type(uint16).max); // skip system contracts
@@ -1606,14 +1606,14 @@ contract AccountTest2 is AccountTestBase {
         assertFalse(account.isAccountManager(otherAddress), "Other address is not an account manager");
     }
 
-    function test_canExecuteTransactions_TrueForOwner(address someManager) public {
+    function test_canExecuteTransactions_TrueForOwner() public view {
         assertTrue(account.canExecuteTransactions(owner), "Owner can execute transactions");
     }
 
     function test_canExecuteTransactions_TrueForManagerWithPermission(address someManager) public {
         _assumeCanBeAddedAsManager(someManager);
         _setManagerWithoutFundManagementPermission(someManager);
-        assertTrue(account.canExecuteTransactions(someManager), "Manager with permision can execute transactions");
+        assertTrue(account.canExecuteTransactions(someManager), "Manager with permission can execute transactions");
     }
 
     function test_canExecuteTransactions_FalseForManagerWithoutPermission(address someManager) public {
@@ -1629,7 +1629,9 @@ contract AccountTest2 is AccountTestBase {
                 canSetMetadataURI: true
             })
         );
-        assertFalse(account.canExecuteTransactions(someManager), "Manager without permision cannot execute transactions");
+        assertFalse(
+            account.canExecuteTransactions(someManager), "Manager without permission cannot execute transactions"
+        );
     }
 
     function test_canExecuteTransactions_FalseForRemovedManager(address someManager) public {
@@ -1645,14 +1647,16 @@ contract AccountTest2 is AccountTestBase {
                 canSetMetadataURI: true
             })
         );
-        assertTrue(account.canExecuteTransactions(someManager), "Manager with permision can execute transactions");
+        assertTrue(account.canExecuteTransactions(someManager), "Manager with permission can execute transactions");
 
         vm.prank(owner);
         account.removeAccountManager(someManager);
-        assertFalse(account.canExecuteTransactions(someManager), "Manager without permision cannot execute transactions");
+        assertFalse(
+            account.canExecuteTransactions(someManager), "Manager without permission cannot execute transactions"
+        );
     }
 
-    function test_canSetMetadataURI_TrueForOwner() public {
+    function test_canSetMetadataURI_TrueForOwner() public view {
         assertTrue(account.canSetMetadataURI(owner), "Owner can set metadataURI");
     }
 
@@ -1668,7 +1672,7 @@ contract AccountTest2 is AccountTestBase {
                 canSetMetadataURI: true
             })
         );
-        assertTrue(account.canSetMetadataURI(someManager), "Manager with permision can set metadataURI");
+        assertTrue(account.canSetMetadataURI(someManager), "Manager with permission can set metadataURI");
     }
 
     function test_canSetMetadataURI_FalseForManagerWithoutPermission(address someManager, bool canTransferTokens)
@@ -1683,7 +1687,7 @@ contract AccountTest2 is AccountTestBase {
         });
         vm.prank(owner);
         account.addAccountManager(someManager, permissions);
-        assertFalse(account.canSetMetadataURI(someManager), "Manager without permision cannot set metadataURI");
+        assertFalse(account.canSetMetadataURI(someManager), "Manager without permission cannot set metadataURI");
     }
 
     function test_canSetMetadataURI_FalseForRemovedManager(address someManager) public {
@@ -1699,14 +1703,14 @@ contract AccountTest2 is AccountTestBase {
                 canSetMetadataURI: true
             })
         );
-        assertTrue(account.canSetMetadataURI(someManager), "Manager with permision can set metadataURI");
+        assertTrue(account.canSetMetadataURI(someManager), "Manager with permission can set metadataURI");
 
         vm.prank(owner);
         account.removeAccountManager(someManager);
         assertFalse(account.canSetMetadataURI(someManager), "Removed manager cannot set metadataURI");
     }
 
-    function test_canSetMetadataURI_FalseForRandomAddress(address randomAddress) public {
+    function test_canSetMetadataURI_FalseForRandomAddress(address randomAddress) public view {
         vm.assume(randomAddress != owner);
         vm.assume(account.isAccountManager(randomAddress) == false);
 
@@ -2254,7 +2258,7 @@ contract AccountTest3 is AccountTestBase {
         account.removeAccountManager(someManager);
     }
 
-    function test_supportsInterface() public {
+    function test_supportsInterface() public view {
         assertTrue(account.supportsInterface(type(IERC1155Receiver).interfaceId));
         assertFalse(account.supportsInterface(0xdeadbeef));
     }
@@ -2270,7 +2274,7 @@ contract AccountTestHarness is FuzzZkTest, BaseDeployments {
         account = IHarnessAccount(payable(address(new HarnessAccount(address(GHO), address(WGHO)))));
     }
 
-    function test_extractGraphFromParams(address addressToExtract) public {
+    function test_extractGraphFromParams(address addressToExtract) public view {
         KeyValue memory kv1 = KeyValue({key: keccak256("key1"), value: abi.encode("value1")});
         KeyValue memory kv2 = KeyValue({key: PARAM__GRAPH, value: abi.encode(addressToExtract)});
         KeyValue memory kv3 = KeyValue({key: keccak256("key3"), value: abi.encode("value3")});

--- a/test/harness/HarnessAccount.sol
+++ b/test/harness/HarnessAccount.sol
@@ -1,8 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+// Copyright (C) 2024 Lens Labs. All Rights Reserved.
 pragma solidity ^0.8.26;
 
 import {Account} from "contracts/extensions/account/Account.sol";
 import {IAccount} from "contracts/extensions/account/IAccount.sol";
-import {IOwnable} from "contracts/core/interfaces/IOwnable.sol";
 import {KeyValue} from "contracts/core/types/Types.sol";
 
 interface IHarnessAccount is IAccount {


### PR DESCRIPTION
Unreachable code warning was being triggered "wrong". Basically, it was pointing out code that was indeed reachable thorugh inheritance.

Having warnings that we cannot remove leads to getting used to see warnings after compilation, which can also lead to ignore some relevant new warning (you are used to see 4 warnings in your compilation, so maybe you don't notice a 5ft one that appeared!).

After discussion, we preferred to supress the "unrechable code" warning, giving that is very unlikely to get to that warning when you carefully code, but is easy to get a "false positive".

This PR leaves the code with 0 warnings.