### PR TITLE
feat: ProxyAdminForOwnable restricted to only BeaconProxy admin calls

### DIFF
--- a/contracts/core/upgradeability/ProxyAdminForOwnable.sol
+++ b/contracts/core/upgradeability/ProxyAdminForOwnable.sol
@@ -25,25 +25,22 @@ contract ProxyAdminForOwnable {
     }
 
     function call(address to, uint256 value, bytes calldata data) external payable returns (bytes memory) {
-        bytes4 selector = bytes4(data);
-        if (LOCK.isLocked(to)) {
-            // While the Proxy Admin is locked it:
-            // - Cannot change Proxy Admin in the Proxy, only in the ProxyAdmin contract itself
-            require(selector != BeaconProxy.proxy__changeProxyAdmin.selector, Errors.Locked());
-            // - Cannot change the Beacon in the Proxy
-            require(selector != BeaconProxy.proxy__setBeacon.selector, Errors.Locked());
-            // - Cannot change the implementation in the Proxy
-            require(selector != BeaconProxy.proxy__setImplementation.selector, Errors.Locked());
-            // - Cannot trigger an upgrade in the Proxy
-            require(selector != BeaconProxy.proxy__triggerUpgradeToVersion.selector, Errors.Locked());
-            require(selector != BeaconProxy.proxy__triggerUpgrade.selector, Errors.Locked());
-            // - Cannot opt-out from auto-upgrade in the Proxy
-            require(selector != BeaconProxy.proxy__optOutFromAutoUpgrade.selector, Errors.Locked());
-            // - Cannot opt-in to auto-upgrade in the Proxy
-            require(selector != BeaconProxy.proxy__optInToAutoUpgrade.selector, Errors.Locked());
-        }
-        // Require the msg.sender to match the owner
         require(msg.sender == IOwnable(to).owner(), Errors.InvalidMsgSender());
+        bytes4 selector = bytes4(data[:4]);
+
+        // Require the contract to be unlocked to do anything at all
+        require(LOCK.isLocked(to) == false, Errors.Locked());
+
+        // You can only call the following functions of the BeaconProxy:
+        require(
+            selector == BeaconProxy.proxy__changeProxyAdmin.selector || selector == BeaconProxy.proxy__setBeacon.selector
+                || selector == BeaconProxy.proxy__setImplementation.selector
+                || selector == BeaconProxy.proxy__triggerUpgrade.selector
+                || selector == BeaconProxy.proxy__triggerUpgradeToVersion.selector
+                || selector == BeaconProxy.proxy__optOutFromAutoUpgrade.selector
+                || selector == BeaconProxy.proxy__optInToAutoUpgrade.selector,
+            Errors.NotAllowed()
+        );
         bytes memory returnData = to.handledsafecall(value, data);
         // Require the owner to not be altered by the executed transaction
         require(IOwnable(to).owner() == msg.sender, Errors.UnexpectedValue());

--- a/contracts/core/upgradeability/ProxyAdminForOwnable.sol
+++ b/contracts/core/upgradeability/ProxyAdminForOwnable.sol
@@ -7,6 +7,7 @@ import {IOwnable} from "contracts/core/interfaces/IOwnable.sol";
 import {BeaconProxy} from "contracts/core/upgradeability/BeaconProxy.sol";
 import {CallLib} from "contracts/core/libraries/CallLib.sol";
 import {Errors} from "contracts/core/types/Errors.sol";
+import {SELECTOR_BYTE_LENGTH} from "contracts/core/types/Constants.sol";
 
 /**
  * Contract to ensure that the proxy admin is synced with the underlying contract's owner.
@@ -26,11 +27,9 @@ contract ProxyAdminForOwnable {
 
     function call(address to, uint256 value, bytes calldata data) external payable returns (bytes memory) {
         require(msg.sender == IOwnable(to).owner(), Errors.InvalidMsgSender());
-        bytes4 selector = bytes4(data[:4]);
-
+        bytes4 selector = bytes4(data[:SELECTOR_BYTE_LENGTH]);
         // Require the contract to be unlocked to do anything at all
         require(LOCK.isLocked(to) == false, Errors.Locked());
-
         // You can only call the following functions of the BeaconProxy:
         require(
             selector == BeaconProxy.proxy__changeProxyAdmin.selector || selector == BeaconProxy.proxy__setBeacon.selector

--- a/test/mocks/MockImmutableOwnable.sol
+++ b/test/mocks/MockImmutableOwnable.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: UNLICENSED
+// Copyright (C) 2024 Lens Labs. All Rights Reserved.
+pragma solidity ^0.8.26;
+
+contract MockImmutableOwnable {
+    address immutable _owner;
+
+    constructor(address initialOwner) {
+        _owner = initialOwner;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}

--- a/test/mocks/MockMutableOwnable.sol
+++ b/test/mocks/MockMutableOwnable.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: UNLICENSED
+// Copyright (C) 2024 Lens Labs. All Rights Reserved.
+pragma solidity ^0.8.26;
+
+contract MockMutableOwnable {
+    address immutable _initialOwner;
+    address internal _mockedOwner;
+
+    constructor(address initialOwner) {
+        _initialOwner = initialOwner;
+    }
+
+    function owner() external view returns (address) {
+        return _mockedOwner == address(0) ? _initialOwner : _mockedOwner;
+    }
+
+    function mockOwner(address newOwner) external {
+        _mockedOwner = newOwner;
+    }
+}

--- a/test/upgradeability/ProxyAdminForOwnable.t.sol
+++ b/test/upgradeability/ProxyAdminForOwnable.t.sol
@@ -9,6 +9,8 @@ import {BeaconProxy} from "@core/upgradeability/BeaconProxy.sol";
 import {MockVersionedBeacon} from "test/mocks/MockVersionedBeacon.sol";
 import {Errors} from "@core/types/Errors.sol";
 import {MockOwnableUniversal} from "test/mocks/MockOwnableUniversal.sol";
+import {MockImmutableOwnable} from "test/mocks/MockImmutableOwnable.sol";
+import {MockMutableOwnable} from "test/mocks/MockMutableOwnable.sol";
 import {IOwnable} from "@core/interfaces/IOwnable.sol";
 
 contract ProxyAdminForOwnableTest is Test {
@@ -178,7 +180,7 @@ contract ProxyAdminForOwnableTest is Test {
         assertTrue(beaconProxy.proxy__getAutoUpgrade());
     }
 
-    function test_Call_OtherSelectors_RegardlessOfLockStatus(bytes4 selector, bool locked) public {
+    function test_Cannot_Call_OtherSelectors(bytes4 selector) public {
         vm.assume(selector != BeaconProxy.proxy__changeProxyAdmin.selector);
         vm.assume(selector != BeaconProxy.proxy__setBeacon.selector);
         vm.assume(selector != BeaconProxy.proxy__setImplementation.selector);
@@ -187,10 +189,11 @@ contract ProxyAdminForOwnableTest is Test {
         vm.assume(selector != BeaconProxy.proxy__optOutFromAutoUpgrade.selector);
         vm.assume(selector != BeaconProxy.proxy__optInToAutoUpgrade.selector);
 
-        lock.setLockStatus(locked);
+        lock.setLockStatus(false);
 
         bytes memory data = abi.encodeWithSelector(selector);
 
+        vm.expectRevert(Errors.NotAllowed.selector);
         proxyAdmin.call(address(beaconProxy), 0, data);
     }
 
@@ -212,30 +215,6 @@ contract ProxyAdminForOwnableTest is Test {
         proxyAdmin.call(address(eoa), 0, data);
     }
 
-    function test_Call_RevertsWithSameStringMessage_AsTargetContractReverted(bytes4 selector) public {
-        lock.setLockStatus(false);
-
-        bytes memory data = abi.encodeWithSelector(selector);
-
-        MockOwnableUniversal(address(beaconProxy)).mockToRevertOnNextCallWith("Some error message");
-
-        vm.expectRevert("Some error message");
-        proxyAdmin.call(address(beaconProxy), 0, data);
-    }
-
-    function test_Call_RevertsWithSameErrorSelector_AsTargetContractReverted(bytes4 selector, bytes4 errorSelector)
-        public
-    {
-        lock.setLockStatus(false);
-
-        bytes memory data = abi.encodeWithSelector(selector);
-
-        MockOwnableUniversal(address(beaconProxy)).mockToRevertOnNextCallWith(errorSelector);
-
-        vm.expectRevert(errorSelector);
-        proxyAdmin.call(address(beaconProxy), 0, data);
-    }
-
     function test_Call_RevertsWithoutMessage_IfTargetContractRevertedWithoutMessage(bytes4 selector) public {
         lock.setLockStatus(false);
 
@@ -247,15 +226,114 @@ contract ProxyAdminForOwnableTest is Test {
         proxyAdmin.call(address(beaconProxy), 0, data);
     }
 
-    function test_Call_Reverts_IfOwnerChangesAfterIt(address newOwner) public {
+    function test_Call_Reverts_IfOwnerChangesOn_setBeacon(address newOwner) public {
         vm.assume(newOwner != IOwnable(address(beaconProxy)).owner());
 
         lock.setLockStatus(false);
 
-        bytes memory data = abi.encodeWithSelector(MockOwnableUniversal.mockOwner.selector, newOwner);
+        MockVersionedBeacon newBeacon = new MockVersionedBeacon();
+        MockImmutableOwnable newDefaultImplementation = new MockImmutableOwnable(newOwner);
+        newBeacon.mockImplementation(address(newDefaultImplementation));
 
         vm.expectRevert(Errors.UnexpectedValue.selector);
-        proxyAdmin.call(address(beaconProxy), 0, data);
+        proxyAdmin.call(
+            address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__setBeacon.selector, newBeacon)
+        );
+    }
+
+    function test_Call_Reverts_IfOwnerChangesOn_setImplementation(address newOwner) public {
+        vm.assume(newOwner != IOwnable(address(beaconProxy)).owner());
+
+        lock.setLockStatus(false);
+
+        proxyAdmin.call(
+            address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__optOutFromAutoUpgrade.selector)
+        );
+
+        MockImmutableOwnable newDefaultImplementation = new MockImmutableOwnable(newOwner);
+
+        vm.expectRevert(Errors.UnexpectedValue.selector);
+        proxyAdmin.call(
+            address(beaconProxy),
+            0,
+            abi.encodeWithSelector(BeaconProxy.proxy__setImplementation.selector, newDefaultImplementation)
+        );
+    }
+
+    function test_Call_Reverts_IfOwnerChangesOn_optInToAutoUpgrade(address newOwner) public {
+        vm.assume(newOwner != IOwnable(address(beaconProxy)).owner());
+
+        lock.setLockStatus(false);
+
+        MockMutableOwnable newDefaultImplementation = new MockMutableOwnable(address(this));
+
+        proxyAdmin.call(
+            address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__optOutFromAutoUpgrade.selector)
+        );
+
+        proxyAdmin.call(
+            address(beaconProxy),
+            0,
+            abi.encodeWithSelector(BeaconProxy.proxy__setImplementation.selector, address(newDefaultImplementation))
+        );
+
+        MockMutableOwnable(address(beaconProxy)).mockOwner(newOwner);
+
+        vm.expectRevert(Errors.UnexpectedValue.selector);
+        vm.prank(newOwner);
+        proxyAdmin.call(address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__optInToAutoUpgrade.selector));
+    }
+
+    function test_Call_Reverts_IfOwnerChangesOn_triggerUpgrade(address newOwner) public {
+        vm.assume(newOwner != IOwnable(address(beaconProxy)).owner());
+
+        lock.setLockStatus(false);
+
+        MockImmutableOwnable newCustomImplementation = new MockImmutableOwnable(address(this));
+
+        proxyAdmin.call(
+            address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__optOutFromAutoUpgrade.selector)
+        );
+
+        proxyAdmin.call(
+            address(beaconProxy),
+            0,
+            abi.encodeWithSelector(BeaconProxy.proxy__setImplementation.selector, address(newCustomImplementation))
+        );
+
+        MockImmutableOwnable newDefaultImplementation = new MockImmutableOwnable(newOwner);
+
+        beacon.mockImplementation(address(newDefaultImplementation));
+
+        vm.expectRevert(Errors.UnexpectedValue.selector);
+        proxyAdmin.call(address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__triggerUpgrade.selector));
+    }
+
+    function test_Call_Reverts_IfOwnerChangesOn_triggerUpgradeToVersion(address newOwner) public {
+        vm.assume(newOwner != IOwnable(address(beaconProxy)).owner());
+
+        lock.setLockStatus(false);
+
+        MockImmutableOwnable newCustomImplementation = new MockImmutableOwnable(address(this));
+
+        proxyAdmin.call(
+            address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__optOutFromAutoUpgrade.selector)
+        );
+
+        proxyAdmin.call(
+            address(beaconProxy),
+            0,
+            abi.encodeWithSelector(BeaconProxy.proxy__setImplementation.selector, address(newCustomImplementation))
+        );
+
+        MockImmutableOwnable newDefaultImplementation = new MockImmutableOwnable(newOwner);
+
+        beacon.mockImplementationForVersion(1, address(newDefaultImplementation));
+
+        vm.expectRevert(Errors.UnexpectedValue.selector);
+        proxyAdmin.call(
+            address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__triggerUpgradeToVersion.selector, 1)
+        );
     }
 
     function test_Call_Reverts_IfWrongOwner(address nonOwner) public {
@@ -277,7 +355,11 @@ contract ProxyAdminForOwnableTest is Test {
 
         assertEq(IOwnable(address(beaconProxy)).owner(), address(this));
 
-        bytes memory data = abi.encodeWithSelector(IOwnable.owner.selector);
+        proxyAdmin.call(
+            address(beaconProxy), 0, abi.encodeWithSelector(BeaconProxy.proxy__optOutFromAutoUpgrade.selector)
+        );
+
+        bytes memory data = abi.encodeWithSelector(BeaconProxy.proxy__triggerUpgrade.selector);
 
         vm.prank(newOwner);
         vm.expectRevert(Errors.InvalidMsgSender.selector);
@@ -329,20 +411,6 @@ contract ProxyAdminForOwnableTest is Test {
         data = abi.encodeWithSelector(BeaconProxy.proxy__setImplementation.selector, newOwnerImplementation);
 
         vm.expectRevert();
-        proxyAdmin.call(address(beaconProxy), 0, data);
-    }
-
-    function test_Call_Reverts_IfOwnerChangesDuringCall_NoUpgradeCall(address newOwner) public {
-        vm.assume(newOwner != address(this));
-
-        assertEq(IOwnable(address(beaconProxy)).owner(), address(this));
-
-        MockOwnableUniversal(address(beaconProxy)).mockOwnerOnNextCall(newOwner);
-
-        // Intentionally invalid selector to go through the fallback function.
-        bytes memory data = abi.encodeWithSelector(bytes4(0xC00FEE00));
-
-        vm.expectRevert(Errors.UnexpectedValue.selector);
         proxyAdmin.call(address(beaconProxy), 0, data);
     }
 }


### PR DESCRIPTION
More restrictive ProxyAdminForOwnable.

Arbitrary calls are not allowed anymore.
No calls are allowed in Locked state.
Only BeaconProxy admin calls (upgrade related, etc) are allowed, and only if not Locked.