### PR TITLE
docs: clarify atomic behavior of open actions in Lens v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,6 @@ Contains contracts implementing Lens Rules. These also serve as examples of how 
 ### Actions
 
 Contains contracts implementing Lens Actions. These also serve as examples of how developers could build their own Actions.
+> Note: In Lens v3, open actions attached to a publication are executed atomically.
+> If any attached action reverts, the entire publication transaction is reverted.
+


### PR DESCRIPTION
This PR adds a short note clarifying the atomic behavior of open actions in Lens v3.

When multiple open actions are attached to a publication, they are executed atomically.
If any attached action reverts, the entire publication transaction is reverted.

This helps developers set correct expectations when composing multiple open actions
in a single publication. Documentation-only change, no code modifications.
